### PR TITLE
Release 环境自包含与打包管线（保留分支，暂不合并）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: XL Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '发布版本号（不带 v 前缀，如 1.60.2）'
+        required: false
+        default: '1.60.2'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up JDK (Temurin 21, for jlink/jdeps)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Resolve version
+        id: ver
+        shell: pwsh
+        run: |
+          if ("${{ github.event.inputs.version }}") {
+            $v = "${{ github.event.inputs.version }}"
+          } else {
+            $v = "${{ github.ref_name }}" -replace '^v', ''
+          }
+          echo "version=$v" >> $env:GITHUB_OUTPUT
+          echo "Release version: $v"
+
+      - name: Build release (prepare runtimes, stage tools, tests, pyinstaller, self-check, zip)
+        shell: pwsh
+        run: |
+          .\scripts\release\build-release.ps1 -Version "${{ steps.ver.outputs.version }}" -NoVenv
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: XL-${{ steps.ver.outputs.version }}-win-x64-portable
+          path: |
+            release/*.zip
+            release/SHA256SUMS.txt
+            build/size-report.txt
+          if-no-files-found: error
+
+      - name: Publish GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            release/*.zip
+            release/SHA256SUMS.txt
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@ xl_updata_tool/tools/AssetStudio/Maps/
 dist/
 build/
 
+# Release 发布产物与私有运行时（前导 / 锚定仓库根，避免误伤 scripts/release/）
+/release/
+/xl_updata_tool/runtimes/
+/xl_updata_tool/dist/
+
 # IDE
 .idea/
 .vscode/

--- a/scripts/release/build-release.ps1
+++ b/scripts/release/build-release.ps1
@@ -174,13 +174,15 @@ Invoke-Step '组件体积报告' {
     }
     $rows = [System.Collections.Generic.List[psobject]]::new()
     $totalMB = Get-DirMB $distDir
-    $javaMB   = Get-DirMB (Join-Path $distDir 'runtimes\java')
-    $dotnetMB = Get-DirMB (Join-Path $distDir 'runtimes\dotnet')
-    $toolsMB  = Get-DirMB (Join-Path $distDir 'tools')
+    # PyInstaller 6 onedir：datas/binaries 落在 exe 旁的 _internal/ 子目录
+    $internalDir = Join-Path $distDir '_internal'
+    $javaMB   = Get-DirMB (Join-Path $internalDir 'runtimes\java')
+    $dotnetMB = Get-DirMB (Join-Path $internalDir 'runtimes\dotnet')
+    $toolsMB  = Get-DirMB (Join-Path $internalDir 'tools')
     $rows.Add([pscustomobject]@{ Component = 'Python+Qt+app'; SizeMB = [math]::Round($totalMB - $javaMB - $dotnetMB - $toolsMB, 1) })
     $rows.Add([pscustomobject]@{ Component = 'runtimes/java (jlink JRE)'; SizeMB = $javaMB })
     $rows.Add([pscustomobject]@{ Component = 'runtimes/dotnet (.NET 8)'; SizeMB = $dotnetMB })
-    foreach ($sub in Get-ChildItem (Join-Path $distDir 'tools') -Directory) {
+    foreach ($sub in Get-ChildItem (Join-Path $internalDir 'tools') -Directory) {
         $rows.Add([pscustomobject]@{ Component = "tools/$($sub.Name)"; SizeMB = (Get-DirMB $sub.FullName) })
     }
     $rows.Add([pscustomobject]@{ Component = 'TOTAL (dist/XL)'; SizeMB = $totalMB })

--- a/scripts/release/build-release.ps1
+++ b/scripts/release/build-release.ps1
@@ -1,0 +1,210 @@
+﻿#requires -Version 5.1
+<#
+.SYNOPSIS
+    XL Update Tool Windows Release 一键构建编排。
+.DESCRIPTION
+    清理 -> 准备私有运行时 -> 裁剪 tools -> 安装构建依赖 -> 质量门禁 ->
+    PyInstaller 打包 -> 自检 -> 附带说明文件 -> 体积报告 -> 打 ZIP + SHA256。
+.EXAMPLE
+    .\scripts\release\build-release.ps1
+    .\scripts\release\build-release.ps1 -Version 1.60.2 -SkipTests -SkipRuntimes
+#>
+[CmdletBinding()]
+param(
+    [string]$Version = '1.60.2',
+    [switch]$SkipTests,
+    [switch]$SkipRuntimes,
+    # 默认在 build/.venv 建隔离虚拟环境；加 -NoVenv 则直接使用当前 python
+    [switch]$NoVenv
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot  = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$appDir    = Join-Path $repoRoot 'xl_updata_tool'
+$buildDir  = Join-Path $repoRoot 'build'
+$stageDir  = Join-Path $buildDir 'stage'
+$releaseDir = Join-Path $repoRoot 'release'
+$distDir   = Join-Path $appDir 'dist\XL'
+$workDir   = Join-Path $appDir 'build'
+
+# PS 5.1 下 EAP=Stop 会把外部程序的 stderr 输出变成 NativeCommandError，
+# 统一在本函数内以 Continue 调用原生命令；非零退出码抛错。
+function Invoke-Native([string]$Exe, [string[]]$Arguments) {
+    $eap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        & $Exe @Arguments
+        $code = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $eap
+    }
+    $global:LASTEXITCODE = $code
+    if ($code -ne 0) { throw "命令失败（退出码 $code）: $Exe $($Arguments -join ' ')" }
+}
+
+function Invoke-Step([string]$Name, [scriptblock]$Action) {
+    Write-Host ''
+    Write-Host ("=" * 70) -ForegroundColor DarkGray
+    Write-Host "==> $Name" -ForegroundColor Cyan
+    Write-Host ("=" * 70) -ForegroundColor DarkGray
+    $global:LASTEXITCODE = 0  # 避免上一步残留的退出码误判纯 PowerShell 步骤
+    & $Action
+    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) { throw "步骤失败: $Name（退出码 $LASTEXITCODE）" }
+}
+
+# ---------- 1. 清理 ----------
+Invoke-Step '清理 build/stage、dist、PyInstaller work 目录' {
+    foreach ($p in @($stageDir, (Join-Path $buildDir 'dist'), $distDir, $workDir)) {
+        if (Test-Path $p) { Remove-Item $p -Recurse -Force }
+    }
+    New-Item -ItemType Directory -Path $buildDir -Force | Out-Null
+    New-Item -ItemType Directory -Path $releaseDir -Force | Out-Null
+}
+
+# ---------- 2. 私有运行时 + tools 裁剪 ----------
+if (-not $SkipRuntimes) {
+    Invoke-Step '准备私有 Java 运行时（jlink）' {
+        & (Join-Path $PSScriptRoot 'prepare-java.ps1')
+    }
+    Invoke-Step '准备私有 .NET 8 运行时' {
+        & (Join-Path $PSScriptRoot 'prepare-dotnet.ps1')
+    }
+} else {
+    Write-Host '==> -SkipRuntimes：跳过 prepare-java / prepare-dotnet，使用已有 runtimes/' -ForegroundColor Yellow
+    foreach ($p in @("$appDir\runtimes\java\bin\java.exe", "$appDir\runtimes\dotnet\dotnet.exe")) {
+        if (-not (Test-Path $p)) { throw "-SkipRuntimes 但缺少已生成的运行时: $p（请先去掉 -SkipRuntimes 完整跑一次）" }
+    }
+}
+Invoke-Step '裁剪 tools 到 build/stage/tools' {
+    & (Join-Path $PSScriptRoot 'stage-tools.ps1')
+}
+
+# ---------- 3. Python 环境 + 构建依赖 ----------
+$python = 'python'
+if (-not $NoVenv) {
+    Invoke-Step '创建隔离虚拟环境 build/.venv' {
+        $venvDir = Join-Path $buildDir '.venv'
+        if (-not (Test-Path (Join-Path $venvDir 'Scripts\python.exe'))) {
+            Invoke-Native 'python' @('-m', 'venv', $venvDir)
+        } else {
+            Write-Host "    复用已有 venv: $venvDir"
+        }
+    }
+    $python = Join-Path $buildDir '.venv\Scripts\python.exe'
+}
+Write-Host "==> 使用 Python: $python"
+Invoke-Step '安装构建依赖（requirements-build.txt）' {
+    Invoke-Native $python @('-m', 'pip', 'install', '-r', (Join-Path $appDir 'requirements-build.txt'))
+}
+
+# ---------- 4. 质量门禁 ----------
+if (-not $SkipTests) {
+    Invoke-Step 'pytest -q' {
+        Push-Location $appDir
+        try { Invoke-Native $python @('-m', 'pytest', '-q') }
+        finally { Pop-Location }
+    }
+    Invoke-Step 'ruff check' {
+        Push-Location $appDir
+        try { Invoke-Native $python @('-m', 'ruff', 'check', 'tests', 'app') }
+        finally { Pop-Location }
+    }
+} else {
+    Write-Host '==> -SkipTests：跳过 pytest / ruff' -ForegroundColor Yellow
+}
+
+# ---------- 5. PyInstaller 打包 ----------
+Invoke-Step 'pyinstaller build.spec --noconfirm --clean' {
+    Push-Location $appDir
+    try { Invoke-Native $python @('-m', 'PyInstaller', 'build.spec', '--noconfirm', '--clean') }
+    finally { Pop-Location }
+}
+$xlExe = Join-Path $distDir 'XL.exe'
+if (-not (Test-Path $xlExe)) { throw "打包产物缺失: $xlExe" }
+
+# ---------- 6. 自检 ----------
+Invoke-Step 'XL.exe --self-check' {
+    Invoke-Native $xlExe @('--self-check')
+    Write-Host '    self-check 通过（退出码 0）'
+}
+
+# ---------- 7. 附带文件 ----------
+Invoke-Step '写入 LICENSE / README.txt 到 dist/XL' {
+    $license = Join-Path $repoRoot 'LICENSE'
+    if (Test-Path $license) {
+        Copy-Item $license $distDir
+        Write-Host '    已复制 LICENSE'
+    } else {
+        Write-Host '    仓库根无 LICENSE，跳过' -ForegroundColor Yellow
+    }
+    $readme = @"
+XL Update Tool v$Version (Windows x64 便携版)
+================================================
+
+使用方法：
+  1. 解压本 ZIP 到任意目录（路径不要含特殊权限要求）。
+  2. 双击 XL.exe 启动。
+
+说明：
+  - 本包完全自包含：内置 Python/Qt、Java 运行时（Lua 反编译）、
+    .NET 8 运行时（AssetStudio）、AssetStudio/SpineViewer/vgmstream 等工具。
+  - 无需在系统安装 Python / Java / .NET。
+  - 所有运行数据（下载的 bundle、导出产物、日志）写入 XL.exe 同级的
+    data/、output/、logs/ 目录。
+
+命令行：
+  XL.exe --self-check   环境自检（检查内置运行时与工具是否完整）
+  XL.exe --debug        调试模式（额外日志）
+"@
+    [IO.File]::WriteAllText((Join-Path $distDir 'README.txt'), $readme, [Text.UTF8Encoding]::new($true))
+    Write-Host '    已生成 README.txt'
+}
+
+# ---------- 8. 体积报告 ----------
+$sizeReportPath = Join-Path $buildDir 'size-report.txt'
+Invoke-Step '组件体积报告' {
+    function Get-DirMB([string]$Path) {
+        if (-not (Test-Path $Path)) { return 0.0 }
+        [math]::Round(((Get-ChildItem $Path -Recurse -File -Force -ErrorAction SilentlyContinue |
+            Measure-Object Length -Sum).Sum / 1MB), 1)
+    }
+    $rows = [System.Collections.Generic.List[psobject]]::new()
+    $totalMB = Get-DirMB $distDir
+    $javaMB   = Get-DirMB (Join-Path $distDir 'runtimes\java')
+    $dotnetMB = Get-DirMB (Join-Path $distDir 'runtimes\dotnet')
+    $toolsMB  = Get-DirMB (Join-Path $distDir 'tools')
+    $rows.Add([pscustomobject]@{ Component = 'Python+Qt+app'; SizeMB = [math]::Round($totalMB - $javaMB - $dotnetMB - $toolsMB, 1) })
+    $rows.Add([pscustomobject]@{ Component = 'runtimes/java (jlink JRE)'; SizeMB = $javaMB })
+    $rows.Add([pscustomobject]@{ Component = 'runtimes/dotnet (.NET 8)'; SizeMB = $dotnetMB })
+    foreach ($sub in Get-ChildItem (Join-Path $distDir 'tools') -Directory) {
+        $rows.Add([pscustomobject]@{ Component = "tools/$($sub.Name)"; SizeMB = (Get-DirMB $sub.FullName) })
+    }
+    $rows.Add([pscustomobject]@{ Component = 'TOTAL (dist/XL)'; SizeMB = $totalMB })
+    $table = $rows | Format-Table -AutoSize | Out-String
+    Write-Host $table
+    [IO.File]::WriteAllText($sizeReportPath, "XL v$Version 组件体积报告 ($(Get-Date -Format 'yyyy-MM-dd HH:mm:ss'))`r`n$table", [Text.UTF8Encoding]::new($true))
+    Write-Host "    已写入 $sizeReportPath"
+}
+
+# ---------- 9. ZIP + SHA256 ----------
+Invoke-Step "打包 ZIP 与 SHA256（v$Version）" {
+    $zipName = "XL-v$Version-win-x64-portable.zip"
+    $zipPath = Join-Path $releaseDir $zipName
+    if (Test-Path $zipPath) { Remove-Item $zipPath -Force }
+    Compress-Archive -Path $distDir -DestinationPath $zipPath -CompressionLevel Optimal
+    $zipMB = [math]::Round((Get-Item $zipPath).Length / 1MB, 1)
+    Write-Host "    ZIP: $zipPath ($zipMB MB)"
+
+    $hash = (Get-FileHash -Algorithm SHA256 $zipPath).Hash.ToLower()
+    $sumsPath = Join-Path $releaseDir 'SHA256SUMS.txt'
+    [IO.File]::WriteAllText($sumsPath, "$hash  $zipName`r`n", [Text.UTF8Encoding]::new($false))
+    Write-Host "    SHA256: $hash"
+    Write-Host "    校验文件: $sumsPath"
+}
+
+Write-Host ''
+Write-Host '==> 构建完成！' -ForegroundColor Green
+Write-Host "    产物目录: $distDir"
+Write-Host "    发布包:   $(Join-Path $releaseDir "XL-v$Version-win-x64-portable.zip")"

--- a/scripts/release/build-release.ps1
+++ b/scripts/release/build-release.ps1
@@ -67,9 +67,13 @@ Invoke-Step '清理 build/stage、dist、PyInstaller work 目录' {
 if (-not $SkipRuntimes) {
     Invoke-Step '准备私有 Java 运行时（jlink）' {
         & (Join-Path $PSScriptRoot 'prepare-java.ps1')
+        # 子脚本内部已用 EAP=Stop 保证真实失败会抛错；这里清掉其子进程残留的
+        # LASTEXITCODE（如 jdeps 的告警退出码），避免 pwsh 下误判步骤失败
+        $global:LASTEXITCODE = 0
     }
     Invoke-Step '准备私有 .NET 8 运行时' {
         & (Join-Path $PSScriptRoot 'prepare-dotnet.ps1')
+        $global:LASTEXITCODE = 0
     }
 } else {
     Write-Host '==> -SkipRuntimes：跳过 prepare-java / prepare-dotnet，使用已有 runtimes/' -ForegroundColor Yellow
@@ -79,6 +83,7 @@ if (-not $SkipRuntimes) {
 }
 Invoke-Step '裁剪 tools 到 build/stage/tools' {
     & (Join-Path $PSScriptRoot 'stage-tools.ps1')
+    $global:LASTEXITCODE = 0
 }
 
 # ---------- 3. Python 环境 + 构建依赖 ----------

--- a/scripts/release/build-release.ps1
+++ b/scripts/release/build-release.ps1
@@ -95,8 +95,10 @@ if (-not $NoVenv) {
     $python = Join-Path $buildDir '.venv\Scripts\python.exe'
 }
 Write-Host "==> 使用 Python: $python"
-Invoke-Step '安装构建依赖（requirements-build.txt）' {
+Invoke-Step '安装构建依赖（requirements-build.txt + requirements-dev.txt）' {
     Invoke-Native $python @('-m', 'pip', 'install', '-r', (Join-Path $appDir 'requirements-build.txt'))
+    # 质量门禁的 pytest/ruff 在 dev 依赖里，venv 是全新环境必须显式安装
+    Invoke-Native $python @('-m', 'pip', 'install', '-r', (Join-Path $appDir 'requirements-dev.txt'))
 }
 
 # ---------- 4. 质量门禁 ----------

--- a/scripts/release/prepare-dotnet.ps1
+++ b/scripts/release/prepare-dotnet.ps1
@@ -1,0 +1,84 @@
+﻿#requires -Version 5.1
+<#
+.SYNOPSIS
+    下载并安装私有 .NET 8 运行时（仅 Microsoft.NETCore.App，x64）到 xl_updata_tool/runtimes/dotnet。
+.PARAMETER Version
+    可选，显式指定 8.0.x 版本（如 8.0.20）。未指定时解析最新 8.0.x 并打印。
+#>
+[CmdletBinding()]
+param(
+    [string]$Version
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot   = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$buildDir   = Join-Path $repoRoot 'build'
+$installDir = Join-Path $repoRoot 'xl_updata_tool\runtimes\dotnet'
+$scriptPath = Join-Path $buildDir 'dotnet-install.ps1'
+
+# PS 5.1 下 EAP=Stop 会把外部程序的 stderr 输出变成 NativeCommandError，
+# 统一在本函数内以 Continue 调用原生命令，返回输出文本与退出码。
+function Invoke-Native([string]$Exe, [string[]]$Arguments) {
+    $eap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        # ErrorRecord（来自 stderr）取其 Message，避免混入 "exe :" 前缀
+        $output = (& $Exe @Arguments 2>&1 | ForEach-Object {
+            if ($_ -is [Management.Automation.ErrorRecord]) { $_.Exception.Message } else { "$_" }
+        } | Out-String)
+        $code = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $eap
+    }
+    $global:LASTEXITCODE = $code
+    return @{ Output = $output; ExitCode = $code }
+}
+
+# 兼容旧版 PowerShell 的 TLS
+try { [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12 } catch {}
+
+New-Item -ItemType Directory -Path $buildDir -Force | Out-Null
+
+# --- 解析版本 ---
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    Write-Host '==> [prepare-dotnet] 查询最新 .NET Runtime 8.0.x 版本...'
+    $latestUrl = 'https://builds.dotnet.microsoft.com/dotnet/Runtime/8.0/latest.version'
+    $Version = (Invoke-WebRequest -Uri $latestUrl -UseBasicParsing).Content.Trim()
+    if ($Version -notmatch '^\d+\.\d+\.\d+') { throw "无法解析最新版本号: '$Version'" }
+}
+Write-Host "==> [prepare-dotnet] 目标版本: $Version (Microsoft.NETCore.App, x64)"
+
+# --- 下载 dotnet-install.ps1 ---
+if (-not (Test-Path $scriptPath)) {
+    Write-Host '==> [prepare-dotnet] 下载 dotnet-install.ps1 ...'
+    Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -OutFile $scriptPath -UseBasicParsing
+} else {
+    Write-Host "==> [prepare-dotnet] 复用已有安装脚本: $scriptPath"
+}
+
+# --- 安装（仅 Microsoft.NETCore.App 运行时，不含 SDK/ASP.NET/Desktop） ---
+if (Test-Path $installDir) {
+    Write-Host "==> [prepare-dotnet] 清理旧运行时: $installDir"
+    Remove-Item $installDir -Recurse -Force
+}
+New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+
+Write-Host "==> [prepare-dotnet] 安装到 $installDir ..."
+$global:LASTEXITCODE = 0  # dotnet-install.ps1 是脚本，未必设置 $LASTEXITCODE；先初始化再判断
+& $scriptPath -Runtime dotnet -Architecture x64 -Version $Version -InstallDir $installDir
+if ($LASTEXITCODE -ne 0) { throw "dotnet-install.ps1 失败，退出码 $LASTEXITCODE" }
+
+# --- 验证 ---
+$dotnetExe = Join-Path $installDir 'dotnet.exe'
+if (-not (Test-Path $dotnetExe)) { throw "安装结果缺少 dotnet.exe: $installDir" }
+$r = Invoke-Native $dotnetExe @('--list-runtimes')
+if ($r.ExitCode -ne 0) { throw "dotnet.exe --list-runtimes 验证失败，退出码 $($r.ExitCode)`n$($r.Output)" }
+Write-Host $r.Output
+if ($r.Output -notmatch 'Microsoft\.NETCore\.App 8\.0\.\d+') {
+    throw "验证失败：--list-runtimes 输出不含 Microsoft.NETCore.App 8.0.x`n$($r.Output)"
+}
+
+$sizeMB = [math]::Round(((Get-ChildItem $installDir -Recurse -File | Measure-Object Length -Sum).Sum / 1MB), 1)
+Write-Host "==> [prepare-dotnet] 完成，私有 .NET 运行时体积 ${sizeMB} MB" -ForegroundColor Green

--- a/scripts/release/prepare-dotnet.ps1
+++ b/scripts/release/prepare-dotnet.ps1
@@ -82,3 +82,4 @@ if ($r.Output -notmatch 'Microsoft\.NETCore\.App 8\.0\.\d+') {
 
 $sizeMB = [math]::Round(((Get-ChildItem $installDir -Recurse -File | Measure-Object Length -Sum).Sum / 1MB), 1)
 Write-Host "==> [prepare-dotnet] 完成，私有 .NET 运行时体积 ${sizeMB} MB" -ForegroundColor Green
+

--- a/scripts/release/prepare-java.ps1
+++ b/scripts/release/prepare-java.ps1
@@ -1,0 +1,119 @@
+﻿#requires -Version 5.1
+<#
+.SYNOPSIS
+    用 jlink 为 unluac.jar 生成精简的私有 Java 运行时（xl_updata_tool/runtimes/java）。
+.NOTES
+    需要 JDK 21+（unluac.jar 按 Java 21 编译，class file version 65）。
+.PARAMETER JdkHome
+    可选，显式指定 JDK 根目录（需含 bin/jlink.exe）。默认依次尝试 JAVA_HOME、PATH。
+#>
+[CmdletBinding()]
+param(
+    [string]$JdkHome
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$jarPath  = Join-Path $repoRoot 'xl_updata_tool\tools\lua\unluac.jar'
+$outDir   = Join-Path $repoRoot 'xl_updata_tool\runtimes\java'
+
+# PS 5.1 下 EAP=Stop 会把外部程序的 stderr 输出变成 NativeCommandError，
+# 统一在本函数内以 Continue 调用原生命令，返回输出文本与退出码。
+function Invoke-Native([string]$Exe, [string[]]$Arguments) {
+    $eap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        # ErrorRecord（来自 stderr）取其 Message，避免混入 "exe :" 前缀
+        $output = (& $Exe @Arguments 2>&1 | ForEach-Object {
+            if ($_ -is [Management.Automation.ErrorRecord]) { $_.Exception.Message } else { "$_" }
+        } | Out-String)
+        $code = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $eap
+    }
+    $global:LASTEXITCODE = $code
+    return @{ Output = $output; ExitCode = $code }
+}
+
+Write-Host '==> [prepare-java] 定位 JDK...' -ForegroundColor Cyan
+
+# --- 定位 JDK：优先 -JdkHome，其次 JAVA_HOME，最后 PATH ---
+$candidates = @()
+if ($JdkHome)        { $candidates += $JdkHome }
+if ($env:JAVA_HOME)  { $candidates += $env:JAVA_HOME }
+$jlinkOnPath = Get-Command jlink.exe -ErrorAction SilentlyContinue
+if ($jlinkOnPath) {
+    # PATH 中的 jlink 位于 <jdk>/bin，取其父目录
+    $candidates += (Split-Path $jlinkOnPath.Source -Parent)
+}
+
+$jdk = $null
+foreach ($c in $candidates) {
+    if ($c -and (Test-Path (Join-Path $c 'bin\jlink.exe'))) { $jdk = (Resolve-Path $c).Path; break }
+}
+if (-not $jdk) {
+    throw "未找到含 bin\jlink.exe 的 JDK。请安装 JDK 21+，或设置 JAVA_HOME，或用 -JdkHome 指定。"
+}
+
+$jlinkExe = Join-Path $jdk 'bin\jlink.exe'
+$jdepsExe = Join-Path $jdk 'bin\jdeps.exe'
+$javacExe = Join-Path $jdk 'bin\java.exe'
+
+# --- 校验 JDK 主版本 >= 21 ---
+# unluac.jar 的 class file version 为 65（Java 21），用更低版本 jlink 出的 JRE 无法运行它。
+$r = Invoke-Native $javacExe @('-version')
+$verText = (($r.Output).Trim() -split "`r?`n" | Select-Object -First 1)
+Write-Host "    JDK: $jdk ($verText)"
+if ($verText -notmatch '"?(\d+)') { throw "无法解析 java 版本号: $verText" }
+if ([int]$Matches[1] -lt 21) {
+    throw "JDK 版本过低（需要 >= 21，unluac.jar 按 Java 21 编译）: $verText"
+}
+
+if (-not (Test-Path $jarPath)) { throw "找不到 unluac.jar: $jarPath" }
+
+# --- jdeps 推导模块依赖；失败或为空时回退 java.base ---
+Write-Host '==> [prepare-java] jdeps 分析 unluac.jar 模块依赖...'
+$modules = ''
+$r = Invoke-Native $jdepsExe @('--ignore-missing-deps', '--print-module-deps', $jarPath)
+if ($r.ExitCode -eq 0 -and -not [string]::IsNullOrWhiteSpace($r.Output)) {
+    $modules = (($r.Output).Trim() -split "`r?`n" | Select-Object -Last 1).Trim()
+} else {
+    Write-Warning "jdeps 执行失败（退出码 $($r.ExitCode)），回退 java.base。`n$($r.Output)"
+}
+if ([string]::IsNullOrWhiteSpace($modules)) {
+    $modules = 'java.base'
+    Write-Warning 'jdeps 未输出模块列表，回退 java.base。'
+}
+Write-Host "    模块: $modules"
+
+# --- jlink 生成运行时 ---
+if (Test-Path $outDir) {
+    Write-Host "==> [prepare-java] 清理旧运行时: $outDir"
+    Remove-Item $outDir -Recurse -Force
+}
+New-Item -ItemType Directory -Path (Split-Path $outDir -Parent) -Force | Out-Null
+
+Write-Host "==> [prepare-java] jlink 输出到 $outDir"
+$r = Invoke-Native $jlinkExe @('--add-modules', $modules, '--strip-debug', '--no-man-pages',
+    '--no-header-files', '--compress=2', '--output', $outDir)
+if ($r.ExitCode -ne 0) { throw "jlink 失败，退出码 $($r.ExitCode)`n$($r.Output)" }
+
+# --- 验证 ---
+$javaExe = Join-Path $outDir 'bin\java.exe'
+if (-not (Test-Path $javaExe)) { throw "jlink 输出缺少 bin\java.exe: $outDir" }
+$r = Invoke-Native $javaExe @('-version')
+if ($r.ExitCode -ne 0) { throw "java.exe -version 验证失败，退出码 $($r.ExitCode)`n$($r.Output)" }
+$javaVer = (($r.Output).Trim() -split "`r?`n" | Select-Object -First 1)
+Write-Host "    运行时验证通过: $javaVer"
+
+# 冒烟验证生成的 JRE 能加载 unluac.jar（不带参数应打印用法；出现 LinkageError 即为版本不兼容）
+$r = Invoke-Native $javaExe @('-jar', $jarPath)
+if ($r.Output -match 'UnsupportedClassVersionError|LinkageError') {
+    throw "生成的 JRE 无法运行 unluac.jar（$($Matches[0])）。请用 JDK 21+ 重新运行本脚本。`n$($r.Output)"
+}
+Write-Host '    unluac.jar 加载冒烟通过'
+
+$sizeMB = [math]::Round(((Get-ChildItem $outDir -Recurse -File | Measure-Object Length -Sum).Sum / 1MB), 1)
+Write-Host "==> [prepare-java] 完成，私有 JRE 体积 ${sizeMB} MB" -ForegroundColor Green

--- a/scripts/release/prepare-java.ps1
+++ b/scripts/release/prepare-java.ps1
@@ -117,3 +117,4 @@ Write-Host '    unluac.jar 加载冒烟通过'
 
 $sizeMB = [math]::Round(((Get-ChildItem $outDir -Recurse -File | Measure-Object Length -Sum).Sum / 1MB), 1)
 Write-Host "==> [prepare-java] 完成，私有 JRE 体积 ${sizeMB} MB" -ForegroundColor Green
+

--- a/scripts/release/stage-tools.ps1
+++ b/scripts/release/stage-tools.ps1
@@ -1,0 +1,138 @@
+﻿#requires -Version 5.1
+<#
+.SYNOPSIS
+    将仓库 tools/ 裁剪复制到 build/stage/tools/，供 PyInstaller datas 打包。
+.DESCRIPTION
+    - AssetStudio：排除 GUI 程序集、*.pdb、runtimes 下非 win 平台（只留 win、win-x64）、
+      x86/、14 个本地化目录、log*.txt；保留 CLI 全套、核心 dll、x64/、AI/、Keys.json。
+    - SpineViewer：runtimes 下只留 win、win-x64；排除 *.pdb、data/；其余全留。
+    - vgmstream / epic7_debank_v1_0 / lua：整体复制（epic7 排除 input/、_tempo/）。
+    结束时打印各目录裁剪前后体积对比表（MB）。
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$srcRoot  = Join-Path $repoRoot 'xl_updata_tool\tools'
+$dstRoot  = Join-Path $repoRoot 'build\stage\tools'
+
+if (-not (Test-Path $srcRoot)) { throw "找不到 tools 目录: $srcRoot" }
+
+function Get-DirMB([string]$Path) {
+    if (-not (Test-Path $Path)) { return 0.0 }
+    [math]::Round(((Get-ChildItem $Path -Recurse -File -Force -ErrorAction SilentlyContinue |
+        Measure-Object Length -Sum).Sum / 1MB), 1)
+}
+
+function Invoke-RoboCopy([string]$Src, [string]$Dst, [string[]]$ExcludeDirs, [string[]]$ExcludeFiles) {
+    $args = @($Src, $Dst, '/E', '/NFL', '/NDL', '/NJH', '/NJS', '/NP', '/MT:8')
+    if ($ExcludeDirs)  { $args += '/XD';  $args += $ExcludeDirs }
+    if ($ExcludeFiles) { $args += '/XF';  $args += $ExcludeFiles }
+    & robocopy @args | Out-Null
+    # robocopy 退出码 0-7 均表示成功（8+ 才是失败）
+    if ($LASTEXITCODE -ge 8) { throw "robocopy 失败（退出码 $LASTEXITCODE）: $Src -> $Dst" }
+    $global:LASTEXITCODE = 0
+}
+
+Write-Host '==> [stage-tools] 清理并重建 staging 目录...'
+if (Test-Path $dstRoot) { Remove-Item $dstRoot -Recurse -Force }
+New-Item -ItemType Directory -Path $dstRoot -Force | Out-Null
+
+$report = [System.Collections.Generic.List[psobject]]::new()
+
+# --- AssetStudio ---
+# 本地化目录为 System.CommandLine / GUI 的卫星程序集，仅影响报错文案语言，CLI 功能不受影响
+$asSrc = Join-Path $srcRoot 'AssetStudio'
+$asLocales = 'cs','de','es','fr','it','ja','ko','pl','pt-BR','ru','tr','zh-Hans','zh-Hant'
+$asExcludeDirs = @(
+    'x86',
+    # runtimes 下非 win 平台
+    'browser', 'linux-x64', 'osx-arm64', 'osx-x64', 'win-arm64', 'win-x86'
+) + $asLocales
+# robocopy /XD 按目录名匹配会误伤同名目录，这里的路径均唯一，无冲突
+$asExcludeFiles = @(
+    'AssetStudio.GUI.exe', 'AssetStudio.GUI.dll', 'AssetStudio.GUI.deps.json',
+    'AssetStudio.GUI.dll.config', 'AssetStudio.GUI.runtimeconfig.json',
+    '*.pdb', 'log*.txt'
+)
+$before = Get-DirMB $asSrc
+Write-Host '==> [stage-tools] 复制 AssetStudio（排除 GUI/pdb/x86/非 win 运行时/本地化/日志）...'
+Invoke-RoboCopy $asSrc (Join-Path $dstRoot 'AssetStudio') $asExcludeDirs $asExcludeFiles
+$report.Add([pscustomobject]@{ Component = 'AssetStudio'; BeforeMB = $before; AfterMB = (Get-DirMB (Join-Path $dstRoot 'AssetStudio')) })
+
+# --- SpineViewer ---
+$svSrc = Join-Path $srcRoot 'SpineViewer'
+$svExcludeDirs = @(
+    'data',
+    # runtimes 下非 win 平台（保留 win、win-x64）
+    'browser', 'fedora-x64', 'linux-arm', 'linux-arm64', 'linux-musl-x64', 'linux-x64',
+    'osx', 'osx-arm64', 'osx-x64', 'win-arm64', 'win-x86'
+)
+$svExcludeFiles = @('*.pdb')
+$before = Get-DirMB $svSrc
+Write-Host '==> [stage-tools] 复制 SpineViewer（排除 pdb/data/非 win 运行时，保留 ffmpeg 与双 exe）...'
+Invoke-RoboCopy $svSrc (Join-Path $dstRoot 'SpineViewer') $svExcludeDirs $svExcludeFiles
+$report.Add([pscustomobject]@{ Component = 'SpineViewer'; BeforeMB = $before; AfterMB = (Get-DirMB (Join-Path $dstRoot 'SpineViewer')) })
+
+# --- vgmstream（完整保留） ---
+$vgSrc = Join-Path $srcRoot 'vgmstream'
+$before = Get-DirMB $vgSrc
+Write-Host '==> [stage-tools] 复制 vgmstream（完整）...'
+Invoke-RoboCopy $vgSrc (Join-Path $dstRoot 'vgmstream') @() @()
+$report.Add([pscustomobject]@{ Component = 'vgmstream'; BeforeMB = $before; AfterMB = (Get-DirMB (Join-Path $dstRoot 'vgmstream')) })
+
+# --- epic7_debank_v1_0（排除测试输入与临时目录） ---
+$e7Src = Join-Path $srcRoot 'epic7_debank_v1_0'
+$before = Get-DirMB $e7Src
+Write-Host '==> [stage-tools] 复制 epic7_debank_v1_0（排除 input/、_tempo/）...'
+Invoke-RoboCopy $e7Src (Join-Path $dstRoot 'epic7_debank_v1_0') @('input', '_tempo') @()
+$report.Add([pscustomobject]@{ Component = 'epic7_debank_v1_0'; BeforeMB = $before; AfterMB = (Get-DirMB (Join-Path $dstRoot 'epic7_debank_v1_0')) })
+
+# --- lua（整体复制，含 unluac.jar） ---
+$luaSrc = Join-Path $srcRoot 'lua'
+$before = Get-DirMB $luaSrc
+Write-Host '==> [stage-tools] 复制 lua（完整）...'
+Invoke-RoboCopy $luaSrc (Join-Path $dstRoot 'lua') @() @()
+$report.Add([pscustomobject]@{ Component = 'lua'; BeforeMB = $before; AfterMB = (Get-DirMB (Join-Path $dstRoot 'lua')) })
+
+# --- 体积对比表 ---
+$totalBefore = ($report | Measure-Object BeforeMB -Sum).Sum
+$totalAfter  = ($report | Measure-Object AfterMB  -Sum).Sum
+$report.Add([pscustomobject]@{ Component = 'TOTAL'; BeforeMB = $totalBefore; AfterMB = $totalAfter })
+
+Write-Host ''
+Write-Host '==> [stage-tools] 裁剪前后体积对比（MB）：' -ForegroundColor Cyan
+$report | Format-Table -AutoSize | Out-String | Write-Host
+
+# --- 关键文件抽查 ---
+$mustExist = @(
+    'AssetStudio\AssetStudio.CLI.exe',
+    'AssetStudio\Keys.json',
+    'SpineViewer\SpineViewer.exe',
+    'SpineViewer\SpineViewerCLI.exe',
+    'SpineViewer\ffmpeg.exe',
+    'epic7_debank_v1_0\_subcontractors\quickbms.exe',
+    'lua\unluac.jar',
+    'vgmstream\vgmstream-cli.exe'
+)
+foreach ($rel in $mustExist) {
+    $p = Join-Path $dstRoot $rel
+    if (-not (Test-Path $p)) { throw "staging 缺少关键文件: $rel" }
+}
+
+$mustAbsent = @(
+    'AssetStudio\AssetStudio.GUI.exe',
+    'AssetStudio\x86',
+    'AssetStudio\zh-Hans',
+    'SpineViewer\runtimes\linux-x64',
+    'SpineViewer\runtimes\osx'
+)
+foreach ($rel in $mustAbsent) {
+    $p = Join-Path $dstRoot $rel
+    if (Test-Path $p) { throw "staging 应已裁剪但仍存在: $rel" }
+}
+
+Write-Host "==> [stage-tools] 完成，${totalBefore} MB -> ${totalAfter} MB" -ForegroundColor Green

--- a/scripts/release/stage-tools.ps1
+++ b/scripts/release/stage-tools.ps1
@@ -136,3 +136,4 @@ foreach ($rel in $mustAbsent) {
 }
 
 Write-Host "==> [stage-tools] 完成，${totalBefore} MB -> ${totalAfter} MB" -ForegroundColor Green
+

--- a/xl_updata_tool/README.md
+++ b/xl_updata_tool/README.md
@@ -25,11 +25,17 @@ MainWindow 作为 Shell 负责导航、页面宿主和通用任务状态；`app/
 
 ## 环境要求
 
+### 运行 Release 版（普通用户）
+
 - Windows 10/11 64 位
-- Python 3.10 或更高版本（推荐 3.12）
-- 已安装 pip
-- Java 21+（Lua 反编译用，需在 PATH 中）
-- .NET 8 运行时（AssetStudio 用）
+- **无需安装任何其他环境**（Python / Java / .NET 均已内置在发布包中）
+
+### 源码开发（开发者）
+
+- Windows 10/11 64 位
+- Python 3.10 或更高版本（推荐 3.12），已安装 pip
+- Java 21+（可选；仅当开发模式需要跑 Lua 反编译且尚未生成 `runtimes/java` 时，需在 PATH 中；unluac.jar 按 Java 21 编译）
+- .NET 8 运行时（可选；AssetStudio 开发模式需要系统安装的 .NET 8，或已由 `scripts/release/prepare-dotnet.ps1` 生成的 `runtimes/dotnet`）
 
 ## 安装步骤
 
@@ -60,6 +66,30 @@ MainWindow 作为 Shell 负责导航、页面宿主和通用任务状态；`app/
    # 方式二：命令行执行
    python main.py
    ```
+
+## 构建 Release（Windows x64 便携包）
+
+在**仓库根目录**（`XL/`）的 PowerShell 中执行一条命令：
+
+```powershell
+.\scripts\release\build-release.ps1
+```
+
+构建脚本会自动完成：jlink 生成精简 Java 运行时、下载私有 .NET 8 运行时、裁剪 `tools/`（去掉非 win 平台运行时、GUI 程序、调试符号）、质量门禁（pytest + ruff）、PyInstaller 打包、自检、体积报告和 ZIP 压缩。
+
+前置条件：本机装有 Python 3.10+ 与 JDK 21+（`JAVA_HOME` 或 PATH 中有 `jlink`），构建过程需要联网（下载 .NET 运行时与 Python 依赖）。
+
+产物：
+
+- `xl_updata_tool/dist/XL/`：解压即用的绿色目录，双击 `XL.exe` 即可运行
+- `release/XL-v<版本>-win-x64-portable.zip` + `release/SHA256SUMS.txt`：发布压缩包与校验文件
+- `build/size-report.txt`：各组件体积报告
+
+发布包完全自包含：内置 Python/Qt、Java 运行时（Lua 反编译）、.NET 8 运行时（AssetStudio）以及 AssetStudio / SpineViewer / vgmstream / QuickBMS 等全部外部工具，目标机器无需安装 Python / Java / .NET。
+
+常用参数：`-Version 1.60.2` 指定版本号；`-SkipTests` 跳过 pytest/ruff；`-SkipRuntimes` 复用已生成的 `runtimes/`（快速迭代）；`-NoVenv` 直接用当前 Python 而不建 `build/.venv`。
+
+打 `v*` 标签推送后，GitHub Actions（`.github/workflows/release.yml`）会自动执行同样的构建并把 ZIP 与校验文件发布到 Release。
 
 ## 使用说明
 

--- a/xl_updata_tool/app/bootstrap/shell_contribution.py
+++ b/xl_updata_tool/app/bootstrap/shell_contribution.py
@@ -12,7 +12,8 @@ from typing import Callable
 
 from app.platform import database as db
 from app.platform.diagnostics import logger
-from app.platform.paths import get_base_dir, get_tools_dir
+from app.platform.paths import get_base_dir
+from app.platform.tool_locator import ToolLocator, ToolNotFoundError
 
 
 @dataclass(frozen=True)
@@ -172,9 +173,16 @@ class ApplicationShellContribution:
                 )
                 shell.status_bar.showMessage("未找到资源映射，将扫描已下载 bundle")
 
-        as_cli = os.path.join(get_tools_dir(), "AssetStudio", "AssetStudio.CLI.exe")
+        locator = ToolLocator.create()
+        try:
+            as_command = locator.assetstudio_command()
+        except ToolNotFoundError as error:
+            logger.error("AssetStudio CLI 不可用: %s", error)
+            shell.show_warning("错误", f"AssetStudio CLI 不可用:\n{error}")
+            return
+        as_cli = as_command[-1]
         if not os.path.exists(as_cli):
-            logger.error("AssetStudio.CLI.exe 不存在: %s", as_cli)
+            logger.error("AssetStudio CLI 不存在: %s", as_cli)
             shell.show_warning("错误", f"AssetStudio CLI 不存在:\n{as_cli}")
             return
         if shell._import_worker is not None:
@@ -205,11 +213,12 @@ class ApplicationShellContribution:
         shell._import_worker = importer.controller.start(
             fs,
             bundle_dir,
-            as_cli,
+            as_command,
             export_categories=export_categories,
             version_timestamp=ts,
             lua_output_dir=os.path.join(str(self.context.output_dir), "lua"),
             isolate_bundle_dir=isolate_bundle_dir,
+            as_env=locator.dotnet_env(),
         )
         shell._import_progress_dialog = shell.create_progress_dialog("正在导入 AS...", "取消")
         shell._import_progress_dialog.canceled.connect(shell._import_worker.cancel)

--- a/xl_updata_tool/app/features/importer/lua_decrypt.py
+++ b/xl_updata_tool/app/features/importer/lua_decrypt.py
@@ -19,6 +19,12 @@ import tempfile
 from PySide6.QtCore import QThread, Signal
 
 from app.platform.diagnostics import logger, task_operation
+from app.platform.tool_locator import ToolLocator
+
+
+def _java_exe():
+    """经 ToolLocator 解析 Java；冻结环境只允许 bundled 运行时。"""
+    return ToolLocator.create().java()
 
 
 FIXED_HEAD = (b'\x1B\x4C\x75\x61\x54\x00\x19\x93\x0D\x0A\x1A\x0A\x04\x08\x08\x78'
@@ -209,7 +215,7 @@ def _decompile_batch(lua_dir, bytecode, unluac_path, opmap_path,
                 fh.write(fixed)
 
         # 批量反编译（单 JVM，多线程）
-        cmd = ['java', '-jar', unluac_path, fixed_dir,
+        cmd = [_java_exe(), '-jar', unluac_path, fixed_dir,
                '--output', out_dir, '--opmap', opmap_path]
         _run_batch(cmd, emit)
 
@@ -267,7 +273,7 @@ def _decompile_single(fixed_data, out_path, unluac_path, opmap_path):
         fh.write(fixed_data)
         tmp_in = fh.name
     try:
-        cmd = ['java', '-jar', unluac_path, tmp_in,
+        cmd = [_java_exe(), '-jar', unluac_path, tmp_in,
                '--output', out_path, '--opmap', opmap_path]
         subprocess.run(cmd, capture_output=True, timeout=120)
         return os.path.isfile(out_path) and os.path.getsize(out_path) > 0

--- a/xl_updata_tool/app/features/importer/processing.py
+++ b/xl_updata_tool/app/features/importer/processing.py
@@ -15,10 +15,11 @@ import tempfile
 import time
 
 from app.platform.diagnostics import logger, timed, stage_operation, task_operation
-from app.platform.paths import get_base_dir, get_tools_dir
+from app.platform.paths import get_base_dir
 from app.platform.bundle_parser import fix_bundle_inplace
 from app.platform.files import replace_directory
 from app.platform.lua_repository import cleanup_lua_staging, publish_lua_version
+from app.platform.tool_locator import ToolLocator
 from .lua_decrypt import decompile_lua_dir
 from app.features.importer.spec import CATEGORY_DIRS, EXPORT_SPECS, build_category_commands
 
@@ -46,11 +47,20 @@ class ImportProcessor:
                  lua_output_dir=None, isolate_bundle_dir=False,
                  progress_stage_callback=None, stage_finished_callback=None,
                  category_finished_callback=None, all_finished_callback=None,
-                 cancel_check=None):
+                 cancel_check=None, as_env=None):
         self.bundle_paths = bundle_paths
         self.bundle_dir = bundle_dir
         self.material_dir = material_dir
-        self.as_cli = as_cli
+        # as_cli 兼容两种形态：单个 exe 路径（旧调用方/测试）或完整命令前缀
+        # 列表（冻结环境为 [dotnet, AssetStudio.CLI.dll]）。统一归一成命令前缀，
+        # 末位始终是 exe/dll 目标文件，供存在性检查、错误信息和 cwd 使用。
+        if isinstance(as_cli, (list, tuple)):
+            self.as_command = [str(part) for part in as_cli]
+        else:
+            self.as_command = [str(as_cli)]
+        self.as_cli = self.as_command[-1]
+        # bundled dotnet 的环境变量覆盖（DOTNET_ROOT 等）；None 表示直接继承父进程环境。
+        self.as_env = dict(as_env) if as_env else None
         self.export_types = export_types
         self.export_categories = export_categories
         self.version_timestamp = version_timestamp
@@ -200,7 +210,7 @@ class ImportProcessor:
     def _stage_map(self):
         """阶段 2: 调用 AssetStudio CLI 生成资源映射"""
         if not os.path.exists(self.as_cli):
-            logger.error(f"[导入AS] AssetStudio.CLI.exe 不存在: {self.as_cli}")
+            logger.error(f"[导入AS] AssetStudio CLI 不存在: {self.as_cli}")
             return None, f"AssetStudio CLI 不存在: {self.as_cli}"
         map_dir = os.path.join(self.bundle_dir, "_map")
         os.makedirs(map_dir, exist_ok=True)
@@ -209,9 +219,10 @@ class ImportProcessor:
         self._emit_progress("解析资源", 0, total_bundles)
         try:
             proc = subprocess.Popen(
-                [self.as_cli, self._cli_bundle_dir, map_dir, "--game", "UnityCN", "--key_index", "23",
+                self.as_command + [self._cli_bundle_dir, map_dir, "--game", "UnityCN", "--key_index", "23",
                  "--map_op", "Both", "--map_type", "JSON"],
-                cwd=os.path.dirname(self.as_cli), stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                cwd=os.path.dirname(self.as_cli), env=self.as_env,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                 text=True, bufsize=1,
                 creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0)
             loaded = 0
@@ -246,7 +257,7 @@ class ImportProcessor:
     def _stage_export(self, assets):
         """阶段 3: 先导出到 staging，成功后再替换 data/material/。"""
         if not os.path.exists(self.as_cli):
-            logger.error(f"[导入AS] AssetStudio.CLI.exe 不存在: {self.as_cli}")
+            logger.error(f"[导入AS] AssetStudio CLI 不存在: {self.as_cli}")
             return 0, f"AssetStudio CLI 不存在: {self.as_cli}"
 
         material_parent = os.path.dirname(os.path.abspath(self.material_dir))
@@ -279,14 +290,14 @@ class ImportProcessor:
                 if self.is_cancelled():
                     return 0, "已取消"
                 self._emit_progress_stage("导出分类", i + 1, total)
-                cmd = [self.as_cli, self._cli_bundle_dir, self._working_material_dir,
+                cmd = self.as_command + [self._cli_bundle_dir, self._working_material_dir,
                        "--game", "UnityCN", "--key_index", "23"] + extra_args + \
                       ["--group_assets", "ByContainer", "--export_type", "Convert"]
                 logger.info(f"[导入AS] {label} 开始（{i + 1}/{total}）: {' '.join(cmd)}")
                 t0 = time.time()
                 try:
                     proc = subprocess.Popen(
-                        cmd, cwd=os.path.dirname(self.as_cli),
+                        cmd, cwd=os.path.dirname(self.as_cli), env=self.as_env,
                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                         text=True, bufsize=1,
                         creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0)
@@ -466,9 +477,9 @@ class ImportProcessor:
         lua_dir = os.path.join(self._working_material_dir, "assets", "lua")
         if not os.path.isdir(lua_dir):
             return
-        tools_dir = get_tools_dir()
-        unluac_path = os.path.join(tools_dir, "lua", "unluac.jar")
-        opmap_path = os.path.join(tools_dir, "lua", "opmap")
+        locator = ToolLocator.create()
+        unluac_path = locator.unluac_jar()
+        opmap_path = locator.unluac_opmap()
         if not os.path.isfile(unluac_path):
             logger.warning("[导入AS] unluac.jar 不存在，跳过 Lua 反编译")
             return

--- a/xl_updata_tool/app/features/importer/worker.py
+++ b/xl_updata_tool/app/features/importer/worker.py
@@ -19,7 +19,7 @@ class ImportWorker(QThread):
 
     def __init__(self, bundle_paths, bundle_dir, material_dir, as_cli, parent=None,
                  export_types=None, export_categories=None, version_timestamp=None,
-                 lua_output_dir=None, isolate_bundle_dir=False):
+                 lua_output_dir=None, isolate_bundle_dir=False, as_env=None):
         super().__init__(parent)
         self.processor = ImportProcessor(
             bundle_paths,
@@ -36,6 +36,7 @@ class ImportWorker(QThread):
             category_finished_callback=self.category_finished.emit,
             all_finished_callback=self.all_finished.emit,
             cancel_check=lambda: self.isInterruptionRequested(),
+            as_env=as_env,
         )
 
     @property

--- a/xl_updata_tool/app/features/preview/controller.py
+++ b/xl_updata_tool/app/features/preview/controller.py
@@ -132,9 +132,9 @@ class PreviewController(QObject):
 
     def start_export_from_tools(self, force=False, selected_roles=None) -> bool:
         """使用项目内 Spine CLI 启动预览导出。"""
-        from app.platform.paths import get_tools_dir
+        from app.platform.tool_locator import ToolLocator
 
-        spine_cli = os.path.join(get_tools_dir(), "SpineViewer", "SpineViewerCLI.exe")
+        spine_cli = ToolLocator.create().spineviewer_cli()
         self.page.preview_progress.setVisible(True)
         self.page.preview_progress.setValue(0)
         return self.start_export(spine_cli, force=force, selected_roles=selected_roles)

--- a/xl_updata_tool/app/features/preview/export_controller.py
+++ b/xl_updata_tool/app/features/preview/export_controller.py
@@ -19,7 +19,8 @@ from app.features.preview.adapter import (
 )
 from app.features.preview.worker import BatchExportWorker, CompositeExportWorker
 from app.platform.diagnostics import logger
-from app.platform.paths import get_base_dir, get_tools_dir
+from app.platform.paths import get_base_dir
+from app.platform.tool_locator import ToolLocator
 from .dialogs.export_settings import ExportSettingsDialog
 
 
@@ -47,7 +48,7 @@ def export_composite_video(controller, png_path, default_format="MP4", skin_name
         QMessageBox.warning(_page(controller), "错误", f"背景 .skel 不存在: {bg_skel}")
         return
 
-    spine_cli = os.path.join(get_tools_dir(), "SpineViewer", "SpineViewerCLI.exe")
+    spine_cli = ToolLocator.create().spineviewer_cli()
     if not os.path.exists(spine_cli):
         QMessageBox.warning(_page(controller), "错误",
                             "SpineViewerCLI.exe 未找到，请确认 tools/SpineViewer/ 目录完整")
@@ -88,7 +89,7 @@ def export_with_dialog(controller, skel_path, atlas_path, default_format="MP4", 
         QMessageBox.warning(_page(controller), "错误", "无法导出，缺少对应的 .atlas 文件")
         return
 
-    spine_cli = os.path.join(get_tools_dir(), "SpineViewer", "SpineViewerCLI.exe")
+    spine_cli = ToolLocator.create().spineviewer_cli()
     if not os.path.exists(spine_cli):
         logger.error("SpineViewerCLI 不存在: %s", spine_cli)
         QMessageBox.warning(_page(controller), "错误",
@@ -146,7 +147,7 @@ def batch_export_with_dialog(controller, entries_with_png, default_format="MP4")
         QMessageBox.warning(_page(controller), "错误", "没有可导出的有效文件")
         return
 
-    spine_cli = os.path.join(get_tools_dir(), "SpineViewer", "SpineViewerCLI.exe")
+    spine_cli = ToolLocator.create().spineviewer_cli()
     if not os.path.exists(spine_cli):
         logger.error("SpineViewerCLI 不存在: %s", spine_cli)
         QMessageBox.warning(_page(controller), "错误",

--- a/xl_updata_tool/app/features/preview/spine_adapter.py
+++ b/xl_updata_tool/app/features/preview/spine_adapter.py
@@ -20,7 +20,7 @@ except ImportError:
     PILLOW_AVAILABLE = False
 
 from app.platform.diagnostics import logger
-from app.platform.paths import get_tools_dir
+from app.platform.tool_locator import ToolLocator
 
 
 def extract_character_id(base_name):
@@ -498,14 +498,10 @@ def export_spine_media_file(spine_cli, skel_path, atlas_path,
 def get_ffmpeg_path():
     """获取 FFmpeg 可执行文件路径
 
-    优先使用 tools/SpineViewer/ffmpeg.exe，若不存在则回退到系统 PATH。
+    路径解析统一收口到 ToolLocator：优先 tools/SpineViewer/ffmpeg.exe，
+    开发模式缺失时回退系统 PATH，冻结模式不回退。
     """
-    local_ffmpeg = os.path.join(get_tools_dir(), "SpineViewer", "ffmpeg.exe")
-    if os.path.exists(local_ffmpeg):
-        logger.debug(f"使用本地 FFmpeg: {local_ffmpeg}")
-        return local_ffmpeg
-    logger.debug("使用系统 PATH 中的 FFmpeg")
-    return "ffmpeg"
+    return ToolLocator.create().ffmpeg()
 
 
 def ffmpeg_composite_videos(bg_path, role_path, output_path, fps, fmt="mp4"):

--- a/xl_updata_tool/app/platform/bundle_parser.py
+++ b/xl_updata_tool/app/platform/bundle_parser.py
@@ -7,24 +7,35 @@ import subprocess
 import tempfile
 import time
 from app.platform.diagnostics import logger
-from app.platform.paths import get_base_dir, get_tools_dir
+from app.platform.paths import get_base_dir
 from app.platform.processes import run_external_process
+from app.platform.tool_locator import ToolLocator, ToolNotFoundError
 
 PROJECT_ROOT = get_base_dir()
-AS_CLI = os.path.join(get_tools_dir(), "AssetStudio", "AssetStudio.CLI.exe")
+
+
+def _assetstudio():
+    """每次调用现场解析：避免模块导入时固化路径，冻结/开发模式由 locator 分流。"""
+    return ToolLocator.create()
 
 
 def _check_as_cli():
-    """检查 AssetStudio.CLI.exe 是否存在，不存在则重试一次"""
-    logger.debug(f"检查 AssetStudio.CLI 路径: {AS_CLI}")
-    if os.path.exists(AS_CLI):
+    """检查 AssetStudio CLI 启动目标（exe 或 dll）是否存在，不存在则重试一次"""
+    locator = _assetstudio()
+    try:
+        target = locator.assetstudio_command()[-1]
+    except ToolNotFoundError as error:
+        logger.error(f"AssetStudio CLI 不可用: {error}")
+        return False
+    logger.debug(f"检查 AssetStudio.CLI 路径: {target}")
+    if os.path.exists(target):
         return True
-    logger.warning(f"AssetStudio.CLI.exe 不存在，1秒后重试: {AS_CLI}")
+    logger.warning(f"AssetStudio CLI 不存在，1秒后重试: {target}")
     time.sleep(1)
-    if os.path.exists(AS_CLI):
-        logger.info(f"AssetStudio.CLI.exe 重试后可用: {AS_CLI}")
+    if os.path.exists(target):
+        logger.info(f"AssetStudio CLI 重试后可用: {target}")
         return True
-    logger.error(f"AssetStudio.CLI.exe 不存在: {AS_CLI}")
+    logger.error(f"AssetStudio CLI 不存在: {target}")
     return False
 
 MAGIC_UNITYFS = b"UnityFS"
@@ -86,15 +97,19 @@ def extract_manifest_hashes(category_path):
 
     logger.debug(f"提取 manifest hash: {os.path.basename(category_path)}")
     out_dir = tempfile.mkdtemp()
+    locator = _assetstudio()
     try:
-        proc = run_external_process([
-            AS_CLI, category_path, out_dir,
-            "--game", "UnityCN", "--key_index", "23",
-            "--group_assets", "ByType",
-            "--export_type", "Convert",
-            "--silent",
-        ], tool="AssetStudio-manifest",
-            cwd=os.path.dirname(AS_CLI),
+        proc = run_external_process(
+            locator.assetstudio_command() + [
+                category_path, out_dir,
+                "--game", "UnityCN", "--key_index", "23",
+                "--group_assets", "ByType",
+                "--export_type", "Convert",
+                "--silent",
+            ], tool="AssetStudio-manifest",
+            # deps/native 解析依赖 AssetStudio 目录作为工作目录
+            cwd=os.path.dirname(locator.assetstudio_dll()),
+            env=locator.subprocess_env(),
             capture_output=True, text=True,
             creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
             timeout=300,
@@ -144,15 +159,18 @@ def extract_manifest_from_dir(category_dir, log_cb=None):
     logger.debug(f"提取 manifest（目录）: {category_dir}")
     out_dir = tempfile.mkdtemp()
     result = {}
+    locator = _assetstudio()
     try:
-        proc = run_external_process([
-            AS_CLI, category_dir, out_dir,
-            "--game", "UnityCN", "--key_index", "23",
-            "--group_assets", "ByType",
-            "--export_type", "Convert",
-            "--silent",
-        ], tool="AssetStudio-manifest-dir",
-            cwd=os.path.dirname(AS_CLI),
+        proc = run_external_process(
+            locator.assetstudio_command() + [
+                category_dir, out_dir,
+                "--game", "UnityCN", "--key_index", "23",
+                "--group_assets", "ByType",
+                "--export_type", "Convert",
+                "--silent",
+            ], tool="AssetStudio-manifest-dir",
+            cwd=os.path.dirname(locator.assetstudio_dll()),
+            env=locator.subprocess_env(),
             capture_output=True, text=True,
             creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
             timeout=300,

--- a/xl_updata_tool/app/platform/environment.py
+++ b/xl_updata_tool/app/platform/environment.py
@@ -12,10 +12,12 @@ from pathlib import Path
 
 from .logger import logger
 from .paths import get_base_dir, get_data_dir, get_output_dir, get_tools_dir
+from .tool_locator import ToolLocator, ToolNotFoundError
 
 
 def collect_environment() -> dict[str, object]:
     base_dir = get_base_dir()
+    locator = ToolLocator.create()
     return {
         "python": sys.version.split()[0],
         "platform": platform.platform(),
@@ -32,13 +34,28 @@ def collect_environment() -> dict[str, object]:
             for name in ("Py" + "Side6", "UnityPy", "psutil")
         },
         "tools": {
-            "java": shutil.which("java") is not None,
-            "dotnet": shutil.which("dotnet") is not None,
-            "assetstudio": os.path.isfile(os.path.join(get_tools_dir(), "AssetStudio", "AssetStudio.CLI.exe")),
-            "vgmstream": os.path.isfile(os.path.join(get_tools_dir(), "vgmstream", "vgmstream-cli.exe")),
-            "quickbms": os.path.isfile(os.path.join(get_tools_dir(), "quickbms", "quickbms.exe")),
+            "java": _runtime_available(locator.java),
+            "dotnet": _runtime_available(locator.dotnet),
+            "assetstudio": os.path.isfile(locator.assetstudio_dll()),
+            "vgmstream": os.path.isfile(locator.vgmstream()),
+            # quickbms 实际位于 epic7_debank 的 _subcontractors/，不是独立目录
+            "quickbms": os.path.isfile(locator.quickbms()),
+            "fsb_aud_extr": os.path.isfile(locator.fsb_extractor()),
+            "unluac": os.path.isfile(locator.unluac_jar()),
+            "spineviewer_cli": os.path.isfile(locator.spineviewer_cli()),
+            "ffmpeg": os.path.isfile(str(locator.tools / "SpineViewer" / "ffmpeg.exe"))
+            or shutil.which("ffmpeg") is not None,
         },
     }
+
+
+def _runtime_available(resolve) -> bool:
+    """bundled 或系统 PATH（仅开发模式）任一可用即视为可用。"""
+    try:
+        resolve()
+    except ToolNotFoundError:
+        return False
+    return True
 
 
 def write_environment_report(directory: str | os.PathLike[str]) -> Path:

--- a/xl_updata_tool/app/platform/runtime_config.py
+++ b/xl_updata_tool/app/platform/runtime_config.py
@@ -16,6 +16,7 @@ class RuntimeConfig:
     """一次应用启动的不可变运行配置。"""
 
     debug: bool = False
+    self_check: bool = False
     extra_args: tuple[str, ...] = ()
 
     @property
@@ -44,5 +45,6 @@ def parse_runtime_config(argv: Sequence[str] | None = None) -> RuntimeConfig:
     """解析 XL 自己的参数，保留 Qt 或启动器可能传入的未知参数。"""
     parser = argparse.ArgumentParser(add_help=True)
     parser.add_argument("--debug", action="store_true", help="启用诊断运行模式")
+    parser.add_argument("--self-check", action="store_true", help="运行 Release 环境自检后退出（不启动界面）")
     args, unknown = parser.parse_known_args(list(argv) if argv is not None else None)
-    return RuntimeConfig(debug=bool(args.debug), extra_args=tuple(unknown))
+    return RuntimeConfig(debug=bool(args.debug), self_check=bool(args.self_check), extra_args=tuple(unknown))

--- a/xl_updata_tool/app/platform/self_check.py
+++ b/xl_updata_tool/app/platform/self_check.py
@@ -1,0 +1,235 @@
+"""Release 环境自检（--self-check）。
+
+打包后的干净机器上没有 Python/Java/.NET 安装，一旦缺少 bundled 组件，
+用户只能看到功能静默失败。自检模式逐项验证资源目录、Python 依赖、
+bundled 运行时（java/dotnet 实际执行）和外部工具文件，输出
+[PASS]/[FAIL] 报告并把报告写入 logs 目录；必要组件缺失时返回退出码 1，
+供启动器、CI 和用户排障使用。
+
+本模块不依赖 Qt，且必须在创建 QApplication 之前可独立运行。
+"""
+
+from __future__ import annotations
+
+import ctypes
+import importlib
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+from .logger import logger
+from .paths import get_data_dir, get_logs_dir, get_output_dir
+from .tool_locator import ToolLocator, ToolNotFoundError, resource_root
+
+# 自检等待外部进程的最长时间；干净机器上首次启动 dotnet 可能触发运行时解压，留足余量。
+PROCESS_TIMEOUT = 30
+# AssetStudio.CLI 是 framework-dependent 构建，运行时必须包含 .NET 8。
+REQUIRED_DOTNET_RUNTIME = "Microsoft.NETCore.App 8.0."
+# (显示名, import 模块名)；Pillow 的 import 名是 PIL，pycryptodome 是 Crypto。
+PYTHON_MODULES = (
+    ("PySide6", "PySide6"),
+    ("Pillow", "PIL"),
+    ("UnityPy", "UnityPy"),
+    ("Crypto", "Crypto"),
+    ("psutil", "psutil"),
+)
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """单项自检结果；critical 为 True 的项失败会让退出码变为 1。"""
+
+    name: str
+    ok: bool
+    detail: str = ""
+    critical: bool = True
+
+
+@dataclass(frozen=True)
+class SelfCheckReport:
+    results: tuple[CheckResult, ...] = field(default_factory=tuple)
+
+    @property
+    def failed(self) -> tuple[CheckResult, ...]:
+        return tuple(result for result in self.results if not result.ok)
+
+    @property
+    def passed(self) -> bool:
+        """所有必要组件通过才算自检通过。"""
+        return all(result.ok or not result.critical for result in self.results)
+
+    @property
+    def exit_code(self) -> int:
+        return 0 if self.passed else 1
+
+
+def run_self_check(session=None, *, locator: ToolLocator | None = None,
+                   report_dir: str | os.PathLike[str] | None = None) -> int:
+    """执行自检、打印并落盘报告，返回进程退出码（0 通过 / 1 失败）。"""
+    _attach_parent_console()
+    locator = locator or ToolLocator.create()
+    report = SelfCheckReport(tuple(_collect_checks(locator)))
+    text = render_report(report)
+
+    # 控制台 print 给双击/命令行用户看；logger 留进会话日志，两者互补。
+    print(text)
+    for line in text.splitlines():
+        logger.info("self_check %s", line)
+
+    try:
+        report_path = _write_report(text, session, report_dir)
+        print(f"报告已写入: {report_path}")
+        logger.info("self_check.report path=%s", report_path)
+    except (OSError, PermissionError) as error:
+        logger.warning("self_check.report_unavailable error=%s", error)
+    return report.exit_code
+
+
+def render_report(report: SelfCheckReport) -> str:
+    """渲染 [PASS]/[FAIL] 文本报告，结尾附汇总与结论。"""
+    lines = ["XL 环境自检报告", "=" * 40]
+    for result in report.results:
+        status = "[PASS]" if result.ok else "[FAIL]"
+        line = f"{status} {result.name}"
+        if result.detail:
+            line += f": {result.detail}"
+        lines.append(line)
+    lines.append("=" * 40)
+    failed = report.failed
+    lines.append(f"汇总: {len(report.results) - len(failed)}/{len(report.results)} 项通过，{len(failed)} 项失败")
+    lines.append("结论: 自检通过" if report.passed else "结论: 自检未通过，存在缺失组件")
+    return "\n".join(lines)
+
+
+def _collect_checks(locator: ToolLocator) -> list[CheckResult]:
+    checks = [_check_resource_root()]
+    checks.extend(_check_writable_dirs())
+    checks.extend(_check_python_modules())
+    checks.append(_check_java(locator))
+    checks.append(_check_dotnet(locator))
+    checks.extend(_check_tool_files(locator))
+    return checks
+
+
+def _check_resource_root() -> CheckResult:
+    root = resource_root()
+    ok = root.is_dir() and os.access(root, os.R_OK)
+    return CheckResult("资源根目录可读", ok, str(root))
+
+
+def _check_writable_dirs() -> list[CheckResult]:
+    return [
+        _check_writable_dir("数据目录可写 data/", get_data_dir()),
+        _check_writable_dir("输出目录可写 output/", get_output_dir()),
+        _check_writable_dir("日志目录可写 logs/", get_logs_dir()),
+    ]
+
+
+def _check_writable_dir(name: str, directory) -> CheckResult:
+    try:
+        path = Path(directory)
+        path.mkdir(parents=True, exist_ok=True)
+        probe = path / ".self-check-probe"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink()
+        return CheckResult(name, True, str(path))
+    except (OSError, PermissionError) as error:
+        return CheckResult(name, False, f"{directory} ({error})")
+
+
+def _check_python_modules() -> list[CheckResult]:
+    results = []
+    for display, module_name in PYTHON_MODULES:
+        try:
+            importlib.import_module(module_name)
+        except ImportError as error:
+            results.append(CheckResult(f"Python 依赖 {display}", False, str(error)))
+        else:
+            results.append(CheckResult(f"Python 依赖 {display}", True, "可导入"))
+    return results
+
+
+def _check_java(locator: ToolLocator) -> CheckResult:
+    try:
+        java = locator.java()
+    except ToolNotFoundError as error:
+        return CheckResult("Java 运行时（java -version）", False, str(error))
+    try:
+        proc = subprocess.run(
+            [java, "-version"],
+            capture_output=True, text=True, timeout=PROCESS_TIMEOUT, check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        return CheckResult("Java 运行时（java -version）", False, f"{java}: {error}")
+    # java -version 的版本信息固定输出到 stderr。
+    detail = (proc.stderr or proc.stdout or "").strip().splitlines()
+    if proc.returncode == 0:
+        return CheckResult("Java 运行时（java -version）", True, detail[0] if detail else java)
+    return CheckResult("Java 运行时（java -version）", False, f"退出码 {proc.returncode}")
+
+
+def _check_dotnet(locator: ToolLocator) -> CheckResult:
+    name = "dotnet 运行时（含 .NET 8）"
+    try:
+        dotnet = locator.dotnet()
+    except ToolNotFoundError as error:
+        return CheckResult(name, False, str(error))
+    try:
+        proc = subprocess.run(
+            [dotnet, "--list-runtimes"],
+            capture_output=True, text=True, timeout=PROCESS_TIMEOUT, check=False,
+            env=locator.subprocess_env(),
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        return CheckResult(name, False, f"{dotnet}: {error}")
+    matched = [line.strip() for line in (proc.stdout or "").splitlines()
+               if REQUIRED_DOTNET_RUNTIME in line]
+    if proc.returncode == 0 and matched:
+        return CheckResult(name, True, matched[0])
+    if proc.returncode != 0:
+        return CheckResult(name, False, f"退出码 {proc.returncode}")
+    return CheckResult(name, False, f"未找到 {REQUIRED_DOTNET_RUNTIME}x 运行时")
+
+
+def _check_tool_files(locator: ToolLocator) -> list[CheckResult]:
+    # ffmpeg 检查 bundled 文件本身：PATH 回退只是开发便利，Release 必须随包携带。
+    files = (
+        ("AssetStudio.CLI.dll", locator.assetstudio_dll()),
+        ("vgmstream-cli.exe", locator.vgmstream()),
+        ("quickbms.exe", locator.quickbms()),
+        ("fsb_aud_extr.exe", locator.fsb_extractor()),
+        ("unluac.jar", locator.unluac_jar()),
+        ("unluac opmap", locator.unluac_opmap()),
+        ("SpineViewerCLI.exe", locator.spineviewer_cli()),
+        ("ffmpeg.exe", str(locator.tools / "SpineViewer" / "ffmpeg.exe")),
+    )
+    return [
+        CheckResult(f"工具文件 {name}", os.path.isfile(path), path)
+        for name, path in files
+    ]
+
+
+def _attach_parent_console() -> None:
+    """冻结的窗口程序（console=False）没有控制台，先尝试附着父控制台再打印。"""
+    if not getattr(sys, "frozen", False) or sys.platform != "win32":
+        return
+    try:
+        ctypes.windll.kernel32.AttachConsole(-1)
+    except (AttributeError, OSError):
+        # 附着失败（如双击启动没有父控制台）不阻塞自检，报告仍会写入 logs。
+        pass
+
+
+def _write_report(text: str, session, report_dir) -> Path:
+    """报告落盘：优先本次日志会话目录，其次指定目录，最后 logs/ 根目录。"""
+    if session is not None:
+        path = Path(session.directory) / "self-check.txt"
+    else:
+        root = Path(report_dir) if report_dir else Path(get_logs_dir())
+        path = root / f"self-check-{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text + "\n", encoding="utf-8")
+    return path

--- a/xl_updata_tool/app/platform/tool_locator.py
+++ b/xl_updata_tool/app/platform/tool_locator.py
@@ -1,0 +1,155 @@
+"""外部工具与 bundled 运行时定位。
+
+Release 打包后的用户机器上没有 Python/Java/.NET，所有外部依赖必须能从
+应用自带的 ``tools/`` 与 ``runtimes/`` 目录解析。本模块是 app/ 内解析
+这些路径的唯一入口，调用方不再各自拼接工具路径：
+
+- 冻结（PyInstaller）模式：资源根为 ``sys._MEIPASS``；运行时只允许使用
+  bundled 副本，找不到即抛 :class:`ToolNotFoundError`，避免静默回退到
+  用户机器上并不存在的系统安装。
+- 开发模式：优先使用 ``runtimes/`` 下的 bundled 副本（由构建脚本生成），
+  不存在时回退系统 PATH，保持开发机现状可用。
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class ToolNotFoundError(FileNotFoundError):
+    """必需的外部工具或 bundled 运行时缺失。
+
+    继承 FileNotFoundError，让既有的 ``except FileNotFoundError`` 容错
+    （如 Lua 反编译的单文件重试）在缺失运行时场景下保持原有行为。
+    """
+
+
+def _is_frozen() -> bool:
+    return bool(getattr(sys, "frozen", False))
+
+
+def resource_root() -> Path:
+    """只读资源根目录：冻结时为 ``sys._MEIPASS``，开发时为项目根目录。"""
+    if _is_frozen():
+        return Path(sys._MEIPASS)
+    # 与 paths.get_base_dir 相同的上溯层级，集中一处避免两份目录约定漂移。
+    from .paths import get_base_dir
+
+    return Path(get_base_dir())
+
+
+@dataclass(frozen=True)
+class ToolLocator:
+    """一次解析、随处复用的外部工具路径集。"""
+
+    root: Path
+    frozen: bool = False
+
+    @classmethod
+    def create(cls) -> "ToolLocator":
+        return cls(root=resource_root(), frozen=_is_frozen())
+
+    @property
+    def tools(self) -> Path:
+        return self.root / "tools"
+
+    @property
+    def runtimes(self) -> Path:
+        return self.root / "runtimes"
+
+    def java(self) -> str:
+        """Java 可执行文件：bundled 优先，仅开发模式允许回退系统 PATH。"""
+        bundled = self.runtimes / "java" / "bin" / "java.exe"
+        if bundled.is_file():
+            return str(bundled)
+        if self.frozen:
+            raise ToolNotFoundError(f"未找到随包 Java 运行时: {bundled}")
+        system = shutil.which("java")
+        if system:
+            return system
+        raise ToolNotFoundError("未找到 Java：runtimes/java 不存在且系统 PATH 中没有 java")
+
+    def dotnet(self) -> str:
+        """dotnet 可执行文件：bundled 优先，仅开发模式允许回退系统 PATH。"""
+        bundled = self.runtimes / "dotnet" / "dotnet.exe"
+        if bundled.is_file():
+            return str(bundled)
+        if self.frozen:
+            raise ToolNotFoundError(f"未找到随包 .NET 运行时: {bundled}")
+        system = shutil.which("dotnet")
+        if system:
+            return system
+        raise ToolNotFoundError("未找到 dotnet：runtimes/dotnet 不存在且系统 PATH 中没有 dotnet")
+
+    def dotnet_env(self) -> dict[str, str]:
+        """bundled dotnet 的环境变量覆盖；无 bundled runtime 时为空 dict。
+
+        framework-dependent 的 CLI 经 bundled dotnet 启动时，需要通过
+        DOTNET_ROOT 指回 bundled 目录，否则会误读机器上其他 .NET 安装。
+        """
+        if not (self.runtimes / "dotnet" / "dotnet.exe").is_file():
+            return {}
+        root = str(self.runtimes / "dotnet")
+        return {"DOTNET_ROOT": root, "DOTNET_ROOT_X64": root}
+
+    def subprocess_env(self) -> dict[str, str]:
+        """完整的 subprocess 环境：os.environ 叠加 bundled 运行时变量。"""
+        env = dict(os.environ)
+        env.update(self.dotnet_env())
+        return env
+
+    def assetstudio_dll(self) -> str:
+        return str(self.tools / "AssetStudio" / "AssetStudio.CLI.dll")
+
+    def assetstudio_command(self) -> list[str]:
+        """AssetStudio.CLI 启动命令前缀（调用方在其后拼接业务参数）。
+
+        AssetStudio.CLI 是 framework-dependent 构建：冻结模式或开发机存在
+        bundled dotnet 时经 ``dotnet AssetStudio.CLI.dll`` 启动；开发机没有
+        bundled runtime 时回退到 exe 直启（依赖开发机自行安装的 .NET 8），
+        保持开发现状可用。
+        """
+        if not self.frozen and not (self.runtimes / "dotnet" / "dotnet.exe").is_file():
+            return [str(self.tools / "AssetStudio" / "AssetStudio.CLI.exe")]
+        return [self.dotnet(), self.assetstudio_dll()]
+
+    def spineviewer_cli(self) -> str:
+        return str(self.tools / "SpineViewer" / "SpineViewerCLI.exe")
+
+    def spineviewer_gui(self) -> str:
+        return str(self.tools / "SpineViewer" / "SpineViewer.exe")
+
+    def ffmpeg(self) -> str:
+        """FFmpeg：优先 tools/SpineViewer/ffmpeg.exe，开发模式回退系统 PATH。
+
+        都找不到时返回裸命令名，沿用调用方现有的 FileNotFoundError 容错
+        （合成导出会记录"FFmpeg 未找到"并跳过，不中断其他导出）。
+        """
+        bundled = self.tools / "SpineViewer" / "ffmpeg.exe"
+        if bundled.is_file():
+            return str(bundled)
+        if not self.frozen:
+            system = shutil.which("ffmpeg")
+            if system:
+                return system
+            return "ffmpeg"
+        return str(bundled)
+
+    def vgmstream(self) -> str:
+        return str(self.tools / "vgmstream" / "vgmstream-cli.exe")
+
+    def quickbms(self) -> str:
+        return str(self.tools / "epic7_debank_v1_0" / "_subcontractors" / "quickbms.exe")
+
+    def fsb_extractor(self) -> str:
+        return str(self.tools / "epic7_debank_v1_0" / "_subcontractors" / "fsb_aud_extr.exe")
+
+    def unluac_jar(self) -> str:
+        return str(self.tools / "lua" / "unluac.jar")
+
+    def unluac_opmap(self) -> str:
+        return str(self.tools / "lua" / "opmap")

--- a/xl_updata_tool/app/ui/asset_browser.py
+++ b/xl_updata_tool/app/ui/asset_browser.py
@@ -19,12 +19,17 @@ from .theme import (
 )
 from app.platform.bundle_parser import fix_bundle_inplace
 from app.platform.diagnostics import logger
-from app.platform.paths import get_base_dir, get_tools_dir
+from app.platform.paths import get_base_dir
+from app.platform.tool_locator import ToolLocator, ToolNotFoundError
 
 _PROJ = get_base_dir()
-AS_CLI = os.path.join(get_tools_dir(), "AssetStudio", "AssetStudio.CLI.exe")
 
 COLUMNS = ["Name", "Type", "Path", "Size", "Hash"]
+
+
+def _assetstudio_command():
+    """AssetStudio CLI 命令前缀（冻结环境经 bundled dotnet 调 dll）。"""
+    return ToolLocator.create().assetstudio_command()
 
 
 class _MultiSelectComboBox(QPushButton):
@@ -206,18 +211,27 @@ class _MapWorker(QThread):
 
     def run(self):
         try:
-            if not os.path.exists(AS_CLI):
-                logger.error(f"AssetStudio.CLI.exe 不存在: {AS_CLI}")
-                self.error.emit(f"AssetStudio CLI 不存在: {AS_CLI}")
+            locator = ToolLocator.create()
+            try:
+                as_command = locator.assetstudio_command()
+            except ToolNotFoundError as error:
+                logger.error(f"AssetStudio CLI 不可用: {error}")
+                self.error.emit(f"AssetStudio CLI 不可用: {error}")
+                return
+            as_target = as_command[-1]
+            if not os.path.exists(as_target):
+                logger.error(f"AssetStudio CLI 不存在: {as_target}")
+                self.error.emit(f"AssetStudio CLI 不存在: {as_target}")
                 return
             md = os.path.join(self._bd, "_map")
             os.makedirs(md, exist_ok=True)
             total_bundles = sum(1 for f in os.listdir(self._bd) if f.lower().endswith(".bundle")) if os.path.isdir(self._bd) else 0
             logger.info(f"[资源浏览器] 解析资源，{total_bundles} 个 bundle")
             proc = subprocess.Popen(
-                [AS_CLI, self._bd, md, "--game", "UnityCN", "--key_index", "23",
+                as_command + [self._bd, md, "--game", "UnityCN", "--key_index", "23",
                  "--map_op", "Both", "--map_type", "JSON"],
-                cwd=os.path.dirname(AS_CLI), stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                cwd=os.path.dirname(as_target), env=locator.subprocess_env(),
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                 text=True, bufsize=1,
                 creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0)
             loaded = 0
@@ -260,18 +274,26 @@ class _ExtractWorker(QThread):
 
     def run(self):
         try:
-            if not os.path.exists(AS_CLI):
-                logger.error(f"AssetStudio.CLI.exe 不存在: {AS_CLI}")
-                self.result.emit(False, f"AssetStudio CLI 不存在: {AS_CLI}", 0)
+            locator = ToolLocator.create()
+            try:
+                as_command = locator.assetstudio_command()
+            except ToolNotFoundError as error:
+                logger.error(f"AssetStudio CLI 不可用: {error}")
+                self.result.emit(False, f"AssetStudio CLI 不可用: {error}", 0)
+                return
+            as_target = as_command[-1]
+            if not os.path.exists(as_target):
+                logger.error(f"AssetStudio CLI 不存在: {as_target}")
+                self.result.emit(False, f"AssetStudio CLI 不存在: {as_target}", 0)
                 return
             os.makedirs(self._od, exist_ok=True)
-            cmd = [AS_CLI, self._bd, self._od, "--game", "UnityCN", "--key_index", "23",
+            cmd = as_command + [self._bd, self._od, "--game", "UnityCN", "--key_index", "23",
                    "--types", ",".join(self._tp), "--group_assets", "ByContainer",
                    "--export_type", "Convert"]
             logger.debug(f"CLI 命令: {' '.join(cmd)}")
             logger.info(f"开始导出资源，类型: {self._tp}")
             proc = subprocess.run(
-                cmd, cwd=os.path.dirname(AS_CLI),
+                cmd, cwd=os.path.dirname(as_target), env=locator.subprocess_env(),
                 capture_output=True, text=True, timeout=300,
                 creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0)
             logger.info(f"CLI 退出码: {proc.returncode}")

--- a/xl_updata_tool/app/ui/main_window.py
+++ b/xl_updata_tool/app/ui/main_window.py
@@ -26,7 +26,8 @@ from .theme import (
 from app.bootstrap import build_app_context, create_application_runtime
 from app.platform import database as db
 from app.platform.diagnostics import logger
-from app.platform.paths import get_data_dir, get_base_dir, get_tools_dir
+from app.platform.paths import get_data_dir, get_base_dir
+from app.platform.tool_locator import ToolLocator
 
 DATA_DIR = get_data_dir()
 BUNDLES_DIR = os.path.join(DATA_DIR, "bundles")
@@ -529,7 +530,7 @@ class MainWindow(QMainWindow):
 
     def _open_spineviewer(self):
         """启动 SpineViewer 独立程序"""
-        sv_exe = os.path.join(get_tools_dir(), "SpineViewer", "SpineViewer.exe")
+        sv_exe = ToolLocator.create().spineviewer_gui()
 
         if not os.path.exists(sv_exe):
             logger.error(f"SpineViewer.exe 未找到: {sv_exe}")

--- a/xl_updata_tool/build.spec
+++ b/xl_updata_tool/build.spec
@@ -71,13 +71,13 @@ a = Analysis(
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 
+# onedir 模式：EXE 不得内嵌 binaries/datas（否则退化成每次启动解压到临时目录的
+# onefile 行为，体积翻倍且启动缓慢）；二进制与数据只交给 COLLECT 落到 _internal/。
 exe = EXE(
     pyz,
     a.scripts,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
     [],
+    exclude_binaries=True,
     name='XL',
     debug=False,
     bootloader_ignore_signals=False,

--- a/xl_updata_tool/build.spec
+++ b/xl_updata_tool/build.spec
@@ -1,10 +1,36 @@
 # -*- mode: python ; coding: utf-8 -*-
-"""XL Update Tool PyInstaller spec (--onedir 模式)"""
+"""XL Update Tool PyInstaller spec（Release 构建，--onedir 模式）
 
-import sys
-from PyInstaller.utils.hooks import collect_data_files
+前置条件（缺失会给出清晰报错）：
+  1. scripts/release/stage-tools.ps1     -> <repo>/build/stage/tools
+  2. scripts/release/prepare-java.ps1    -> xl_updata_tool/runtimes/java
+  3. scripts/release/prepare-dotnet.ps1  -> xl_updata_tool/runtimes/dotnet
+建议直接使用 scripts/release/build-release.ps1 一键编排。
+"""
+
+import os
 
 block_cipher = None
+
+# SPECPATH 由 PyInstaller 注入，为本 spec 文件所在目录（xl_updata_tool/）
+APP_DIR = os.path.abspath(SPECPATH)  # noqa: F821
+REPO_ROOT = os.path.dirname(APP_DIR)
+
+STAGE_TOOLS = os.path.join(REPO_ROOT, 'build', 'stage', 'tools')
+RUNTIMES = os.path.join(APP_DIR, 'runtimes')
+
+_missing = []
+if not os.path.isdir(STAGE_TOOLS):
+    _missing.append(
+        '  - %s\n    请先运行: powershell scripts/release/stage-tools.ps1' % STAGE_TOOLS)
+if not os.path.isdir(RUNTIMES):
+    _missing.append(
+        '  - %s\n    请先运行: powershell scripts/release/prepare-java.ps1 与 '
+        'scripts/release/prepare-dotnet.ps1' % RUNTIMES)
+if _missing:
+    raise SystemExit(
+        '[build.spec] 缺少打包输入目录：\n%s\n'
+        '或直接运行 scripts/release/build-release.ps1 一键构建。' % '\n'.join(_missing))
 
 hiddenimports = [
     'PySide6.QtCore',
@@ -16,19 +42,29 @@ hiddenimports = [
     'psutil',
 ]
 
+# 注意：QtMultimedia / QtMultimediaWidgets 必须保留，音频播放依赖它们。
+excludes = [
+    'tkinter',
+    'PySide6.QtWebEngineCore',
+    'PySide6.QtWebEngineWidgets',
+    'PySide6.Qt3DCore',
+    'PySide6.QtCharts',
+]
+
 a = Analysis(
     ['main.py'],
     pathex=[],
     binaries=[],
     datas=[
         # (源路径, 目标路径) — 打包后相对于 exe 所在目录
-        ('tools', 'tools'),
+        (STAGE_TOOLS, 'tools'),
+        (RUNTIMES, 'runtimes'),
     ],
     hiddenimports=hiddenimports,
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
-    excludes=[],
+    excludes=excludes,
     cipher=block_cipher,
     noarchive=False,
 )
@@ -42,14 +78,14 @@ exe = EXE(
     a.zipfiles,
     a.datas,
     [],
-    name='XL_Update_Tool',
+    name='XL',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
-    upx=True,
+    upx=False,
     upx_exclude=[],
     runtime_tmpdir=None,
-    console=True,          # 保留控制台窗口以查看错误信息，发布时可设为 False
+    console=False,
     disable_windowed_traceback=False,
     argv_emulation=False,
     target_arch=None,
@@ -63,7 +99,7 @@ coll = COLLECT(
     a.zipfiles,
     a.datas,
     strip=False,
-    upx=True,
+    upx=False,
     upx_exclude=[],
-    name='XL_Update_Tool',
+    name='XL',
 )

--- a/xl_updata_tool/docs/worklog/release-hardening-2026-09-07.md
+++ b/xl_updata_tool/docs/worklog/release-hardening-2026-09-07.md
@@ -1,0 +1,100 @@
+# Release 环境自包含改造（platform 公共区）影响说明
+
+> 日期：2026-09-07　分支：feat/release-hardening
+> 范围：`app/platform/`、`app/bootstrap/`、`app/ui/`、三个 Feature 的工具调用点、`tools/epic7_debank_v1_0/epic7_debank.py`
+
+## 背景与目标
+
+打包（PyInstaller）后的目标机器是干净 Windows：没有 Python、Java、.NET。
+改造前代码里存在两类会在干净机器上静默失效的写法：
+
+- 裸命令名调外部工具（`'java'` 起 JVM 反编译 Lua、AssetStudio 直接跑
+  framework-dependent 的 exe 依赖系统 .NET 8）；
+- 冻结模式下 `epic7_debank` 用系统 `python` 跑 QuickBMS `-S` 回调脚本。
+
+本轮把所有外部工具与 bundled 运行时（`runtimes/java`、`runtimes/dotnet`）的
+路径解析收口到 `app/platform/tool_locator.py`，并新增 `--self-check` 自检入口。
+
+## 为什么必须在 platform 公共区做
+
+- 同一工具被多个 Feature/Shell/Platform 模块调用（AssetStudio 有 4 处调用方、
+  SpineViewerCLI 有 4 处、ffmpeg/java 各 2 处以上）；在任一 Feature 内解析都会
+  让其他调用方绕过 bundled runtime，冻结布局约定（`sys._MEIPASS` 下的
+  `tools/` 与 `runtimes/`）本身是平台层契约。
+- `paths.py` 已承担 frozen/dev 分流；tool_locator 复用 `get_base_dir` 的上溯
+  层级，避免第二份目录约定漂移。
+
+## 契约变化：只新增，不改旧契约
+
+新增（不改 output/data/logs 目录契约、Qt 信号、取消语义、命令参数、cwd、超时）：
+
+- `app/platform/tool_locator.py`
+  - `resource_root()`：frozen → `sys._MEIPASS`；dev → 项目根（复用 paths 层级）。
+  - `ToolLocator.create()`（frozen dataclass）：`tools`/`runtimes` 属性，
+    `java()`/`dotnet()`（bundled 优先；dev 回退 `shutil.which`；frozen 禁止回退，
+    缺失抛 `ToolNotFoundError`，继承 `FileNotFoundError` 以兼容既有容错），
+    `assetstudio_dll()`/`assetstudio_command()`（frozen 或有 bundled dotnet 时
+    返回 `[dotnet, dll]`；开发机无 bundled 时回退 `[AssetStudio.CLI.exe]` 单元素，
+    保持开发现状），`spineviewer_cli()`/`spineviewer_gui()`/`ffmpeg()`/
+    `vgmstream()`/`quickbms()`/`fsb_extractor()`/`unluac_jar()`/`unluac_opmap()`，
+    `dotnet_env()`（DOTNET_ROOT/DOTNET_ROOT_X64 指向 bundled runtime），
+    `subprocess_env()`（os.environ 叠加 dotnet_env）。
+- `RuntimeConfig.self_check` + `--self-check` 参数（argparse parse_known_args，
+  未知参数仍入 extra_args）。
+- `app/platform/self_check.py`：`--self-check` 时配置日志后逐项自检
+  （资源根可读、data/output/logs 可写、PySide6/Pillow/UnityPy/Crypto/psutil
+  可导入、java 实际执行 `-version`、dotnet 实际执行 `--list-runtimes` 且含
+  `Microsoft.NETCore.App 8.0.`、8 个工具文件存在），打印 [PASS]/[FAIL] 报告、
+  写入日志会话目录 `self-check.txt`，必要组件缺失退出码 1；不创建 QApplication。
+  frozen(console=False) 下先 `AttachConsole(-1)` 附着父控制台。
+- `ImportProcessor`/`ImportWorker` 新增可选 `as_env` 参数；`as_cli` 兼容
+  字符串路径（旧调用方/测试不变）与命令前缀列表两种形态，内部归一为
+  `as_command`（末位始终是 exe/dll 目标，供存在性检查与 cwd）。
+
+## 工具路径收口清单（全部改走 ToolLocator）
+
+- Java：`features/importer/lua_decrypt.py` 两处 `'java'` → `java()`。
+- AssetStudio：`platform/bundle_parser.py`（2 处）、`ui/asset_browser.py`
+  （2 处）、`bootstrap/shell_contribution.py` → `assetstudio_command()` +
+  `subprocess_env()`；cwd 仍为 AssetStudio 目录（dotnet 调 dll 时 deps/native
+  解析依赖该目录）。
+- SpineViewerCLI：`preview/controller.py`、`preview/export_controller.py`
+  （3 处）→ `spineviewer_cli()`；SpineViewer GUI：`ui/main_window.py` →
+  `spineviewer_gui()`。
+- ffmpeg：`preview/spine_adapter.py:get_ffmpeg_path()` → `ffmpeg()`。
+- unluac.jar/opmap：`features/importer/processing.py` → `unluac_jar()`/
+  `unluac_opmap()`。
+- 环境检查 `platform/environment.py`：quickbms 修正为
+  `epic7_debank_v1_0/_subcontractors/quickbms.exe`（原错查
+  `tools/quickbms/`），java/dotnet 改经 locator，补 fsb_aud_extr/unluac/
+  SpineViewerCLI/ffmpeg 检查项。
+
+## 冻结模式 QuickBMS 回退的限制
+
+`epic7_debank` 的 QuickBMS 阶段通过 `-S` 回调 `_epic7_defsb.py`，必须有一个
+可执行 Python。冻结包内没有解释器，干净机器上系统 PATH 也没有 python。
+本轮改为显式探测：frozen 且 `shutil.which("python")` 为 None 时记录 warning
+并**跳过 QuickBMS 回退**（bank 标记 `quickbms_skipped_no_python` 失败），
+vgmstream 直解与 fsb_aud_extr 兜底不受影响；dev 模式行为不变。
+后续如需在冻结环境恢复 QuickBMS 回退，需随包嵌入 Python 或把回调脚本改写为
+原生工具，超出本轮范围。
+
+## 架构门禁
+
+`tests/test_architecture.py` 新增文本扫描：app/ 生产代码（豁免
+tool_locator.py）不得再出现裸 `'java'`/`"java"` subprocess 调用与
+`AssetStudio.CLI.exe` 硬编码拼装。tools/、tests/ 不在扫描范围。
+
+## 验证
+
+- `python -m pytest -q`：172 passed。
+- `python -m ruff check --no-cache tests app app/bootstrap app/shared`：通过。
+- `python main.py --self-check`：19/19 通过（本机 bundled java/dotnet 已由
+  构建脚本生成），报告写入 logs 会话目录。
+- bundled dotnet 实际拉起 `AssetStudio.CLI.dll`：CLI 正常启动并输出用法。
+
+## 遗留事项
+
+- `runtimes/` 由构建脚本生成、不入库（已在仓库根 .gitignore 登记）。
+- 打包侧（build.spec/scripts/）由并行任务负责，需按
+  `_internal/tools` + `_internal/runtimes/{java,dotnet}` 布局收包。

--- a/xl_updata_tool/docs/代码所有权与边界.md
+++ b/xl_updata_tool/docs/代码所有权与边界.md
@@ -11,7 +11,7 @@
 | 预览 | `app/features/preview/` | `page.py`、`controller.py`、`service.py`、`item.py`、`worker.py`、`workers/`、`dialogs/`、`spine_adapter.py`、`fgui_atlas.py` | 图片、FGUI、Spine、视频导出 |
 | 版本 | `app/features/versions/` | `page.py`、`controller.py`、`service.py`、`worker.py`、`download_worker.py` | 版本列表、检查更新、下载、删除和 Bundle 状态 |
 | 导入 | `app/features/importer/` | `spec.py`、`service.py`、`controller.py`、`postprocessing.py`、`processing.py`、`worker.py`；旧类名兼容入口为 `app/ui/workers/import_as.py` | Bundle、AssetStudio、导出计划、发布事务和后处理结果 |
-| 平台与诊断 | `app/platform/` | `database.py`、`files.py`、`paths.py`、`processes.py`、`downloader.py`、`lua_repository.py`、`logger.py`、`diagnostics.py` 等 | 路径、文件、数据库、进程、网络、Lua 成品发布、日志和诊断 |
+| 平台与诊断 | `app/platform/` | `database.py`、`files.py`、`paths.py`、`processes.py`、`downloader.py`、`lua_repository.py`、`logger.py`、`diagnostics.py`、`tool_locator.py`、`self_check.py` 等 | 路径、文件、数据库、进程、网络、Lua 成品发布、日志和诊断；外部工具与 bundled 运行时（Java/.NET）定位、Release 环境自检 |
 | 共享 UI | `app/shared/qt/` | `app/ui/theme.py`、`widgets/view_chrome.py` | 主题令牌、页头、命令栏、空状态和通用控件 |
 | Shell 与装配 | `app/shell/`、`app/bootstrap/` | `app/ui/main_window.py`、`main.py` | 导航、任务宿主、Feature 注册和运行时装配 |
 

--- a/xl_updata_tool/docs/开发文档指南.md
+++ b/xl_updata_tool/docs/开发文档指南.md
@@ -56,6 +56,8 @@ xl_updata_tool/
     │   │   ├── files.py          # 原子文件/目录操作
     │   │   ├── bundle_parser.py  # Bundle 解析与修复
     │   │   ├── lua_repository.py # Lua 版本目录、原子发布和临时清理
+    │   │   ├── tool_locator.py   # 外部工具与 bundled 运行时（Java/.NET）定位
+    │   │   ├── self_check.py     # --self-check Release 环境自检
     │   │   └── diagnostics.py    # 日志与任务诊断聚合入口
     │   ├── features/             # 功能域页面、控制器、服务与 Worker
     │   │   ├── audio/            # 音频目录、播放、选择和处理
@@ -291,6 +293,7 @@ SQLite 数据库管理，存储版本信息和资源包路径。
 ### Platform/Shared 与工作记录（P6-P8）
 
 - `app/platform/paths.py`、`files.py`、`processes.py`、`database.py`、`diagnostics.py`、`lua_repository.py` 是路径、文件发布、外部进程、数据库、Lua 成品和诊断的稳定入口。
+- `app/platform/tool_locator.py` 是外部工具与 bundled 运行时（Java/.NET）路径的唯一解析入口；`app/platform/self_check.py` 提供 `--self-check` Release 环境自检（不启动界面，退出码即结论）。
 - `app/shared/qt/tokens.py` 和 `chrome.py` 是主题令牌与通用页面壳层的稳定入口；具体 Feature 的业务控件、树、表格和预览逻辑仍归属各自 Feature。
 - 每个跨模块 Issue 在 `docs/worklog/issue-<id>-<slug>/` 保存 `findings.md`、`progress.md`、`verification.md`；`docs/changes/` 保存面向评审的变更摘要。
 - 根 `task_plan.md` 只保留阶段索引和当前任务入口；长期有效的架构边界进入本指南和 ownership 文档，调试过程与验证细节进入 Issue worklog。

--- a/xl_updata_tool/main.py
+++ b/xl_updata_tool/main.py
@@ -13,6 +13,11 @@ from app.platform.runtime_config import parse_runtime_config
 def main(argv=None):
     runtime = parse_runtime_config(sys.argv[1:] if argv is None else argv)
     session = configure_logging(runtime)
+    if runtime.self_check:
+        # 自检只验证环境并输出报告，不创建 QApplication，退出码即结论。
+        from app.platform.self_check import run_self_check
+
+        sys.exit(run_self_check(session))
     crash_reporter = install_crash_reporter(session.directory)
     debug_mode = runtime.debug
     logger.info("application.start mode=%s session=%s", runtime.name, session.session_id)
@@ -31,7 +36,7 @@ def main(argv=None):
 
         app = QApplication(sys.argv)
         app.setApplicationName("XL Update Tool")
-        app.setApplicationVersion("1.0.0")
+        app.setApplicationVersion("1.60.2")
         font = QFont("Microsoft YaHei UI", 10)
         app.setFont(font)
         app_context = build_app_context(runtime)

--- a/xl_updata_tool/requirements-build.txt
+++ b/xl_updata_tool/requirements-build.txt
@@ -1,0 +1,4 @@
+# Release 构建依赖：在 requirements.txt 基础上锁定 PyInstaller 工具链
+-r requirements.txt
+pyinstaller==6.16.0
+pyinstaller-hooks-contrib==2025.8

--- a/xl_updata_tool/tests/test_architecture.py
+++ b/xl_updata_tool/tests/test_architecture.py
@@ -1,4 +1,5 @@
 import ast
+import re
 from pathlib import Path
 
 from app.bootstrap.app_factory import FeatureDefinition, create_features
@@ -234,6 +235,24 @@ def test_platform_implementations_do_not_depend_on_core_compatibility_modules():
     for filename in implementation_names:
         text = (platform_dir / filename).read_text(encoding="utf-8")
         assert not any(module in text for module in forbidden), filename
+
+
+def test_external_tool_launchers_are_resolved_by_tool_locator():
+    """Release 自包含门禁：app/ 生产代码不得裸调 java 或硬编码 AssetStudio.CLI.exe。
+
+    工具路径统一由 app.platform.tool_locator 解析（tools/ 目录、tests 和
+    tool_locator.py 自身不在扫描范围）。
+    """
+    violations = []
+    for path in APP_DIR.rglob("*.py"):
+        if path.name == "tool_locator.py":
+            continue
+        text = path.read_text(encoding="utf-8")
+        if re.search(r"""[\[(]\s*['"]java['"]""", text):
+            violations.append(f"{path.relative_to(APP_DIR)}: 裸 java subprocess 调用")
+        if "AssetStudio.CLI.exe" in text:
+            violations.append(f"{path.relative_to(APP_DIR)}: 硬编码 AssetStudio.CLI.exe")
+    assert violations == []
 
 
 def test_characters_page_and_service_respect_feature_boundaries():

--- a/xl_updata_tool/tests/test_diagnostics.py
+++ b/xl_updata_tool/tests/test_diagnostics.py
@@ -20,6 +20,22 @@ def test_parse_runtime_config_keeps_unknown_qt_arguments():
     assert config.extra_args == ("--platform", "offscreen")
 
 
+def test_parse_runtime_config_supports_self_check():
+    config = parse_runtime_config(["--self-check"])
+
+    assert config.self_check is True
+    assert config.debug is False
+
+    default = parse_runtime_config([])
+    assert default.self_check is False
+
+    # --self-check 可与 --debug 组合，未知参数仍原样保留。
+    combined = parse_runtime_config(["--self-check", "--debug", "--platform", "offscreen"])
+    assert combined.self_check is True
+    assert combined.debug is True
+    assert combined.extra_args == ("--platform", "offscreen")
+
+
 def test_logging_profiles_and_task_context(tmp_path):
     normal = configure_logging(RuntimeConfig(debug=False), logs_dir=tmp_path / "normal")
     logger.debug("normal.debug.should_be_hidden")

--- a/xl_updata_tool/tests/test_self_check.py
+++ b/xl_updata_tool/tests/test_self_check.py
@@ -1,0 +1,147 @@
+import subprocess
+from pathlib import Path
+
+from app.platform import self_check
+from app.platform.self_check import (
+    CheckResult,
+    SelfCheckReport,
+    render_report,
+    run_self_check,
+)
+from app.platform.tool_locator import ToolLocator
+
+
+def _make_release_tree(root: Path) -> ToolLocator:
+    """搭一套完整的冻结布局（tools + runtimes），返回指向它的 locator。"""
+    tools = root / "tools"
+    (tools / "AssetStudio").mkdir(parents=True)
+    (tools / "AssetStudio" / "AssetStudio.CLI.dll").write_bytes(b"placeholder")
+    (tools / "vgmstream").mkdir()
+    (tools / "vgmstream" / "vgmstream-cli.exe").write_bytes(b"placeholder")
+    subcontractors = tools / "epic7_debank_v1_0" / "_subcontractors"
+    subcontractors.mkdir(parents=True)
+    (subcontractors / "quickbms.exe").write_bytes(b"placeholder")
+    (subcontractors / "fsb_aud_extr.exe").write_bytes(b"placeholder")
+    (tools / "lua").mkdir()
+    (tools / "lua" / "unluac.jar").write_bytes(b"placeholder")
+    (tools / "lua" / "opmap").write_bytes(b"placeholder")
+    (tools / "SpineViewer").mkdir()
+    (tools / "SpineViewer" / "SpineViewerCLI.exe").write_bytes(b"placeholder")
+    (tools / "SpineViewer" / "ffmpeg.exe").write_bytes(b"placeholder")
+    (root / "runtimes" / "java" / "bin").mkdir(parents=True)
+    (root / "runtimes" / "java" / "bin" / "java.exe").write_bytes(b"placeholder")
+    (root / "runtimes" / "dotnet").mkdir(parents=True)
+    (root / "runtimes" / "dotnet" / "dotnet.exe").write_bytes(b"placeholder")
+    return ToolLocator(root=root, frozen=True)
+
+
+def _fake_process_run(args, **kwargs):
+    """模拟 java -version / dotnet --list-runtimes 的正常输出。"""
+    exe = str(args[0])
+    if exe.endswith("java.exe"):
+        return subprocess.CompletedProcess(
+            args, 0, stdout="", stderr='openjdk version "17.0.9" 2023-10-17'
+        )
+    if exe.endswith("dotnet.exe"):
+        return subprocess.CompletedProcess(
+            args, 0, stdout="Microsoft.NETCore.App 8.0.16 [C:\\runtimes\\dotnet]", stderr=""
+        )
+    raise AssertionError(f"unexpected subprocess call: {args}")
+
+
+def _isolate_dirs(monkeypatch, tmp_path):
+    """自检会真实探测目录可写性，把它引到测试临时目录，避免碰项目 data/output/logs。"""
+    for name in ("get_data_dir", "get_output_dir", "get_logs_dir"):
+        monkeypatch.setattr(self_check, name, lambda: str(tmp_path))
+    monkeypatch.setattr(self_check, "resource_root", lambda: tmp_path)
+
+
+def test_report_format_and_pass_summary():
+    report = SelfCheckReport((
+        CheckResult("资源根目录可读", True, "E:/XL"),
+        CheckResult("工具文件 unluac.jar", False, "missing"),
+    ))
+
+    text = render_report(report)
+
+    assert "[PASS] 资源根目录可读: E:/XL" in text
+    assert "[FAIL] 工具文件 unluac.jar: missing" in text
+    assert "汇总: 1/2 项通过，1 项失败" in text
+    assert "自检未通过" in text
+    assert report.exit_code == 1
+
+
+def test_all_pass_report_exit_code_zero():
+    report = SelfCheckReport((CheckResult("Java 运行时（java -version）", True, "openjdk 17"),))
+
+    assert report.passed
+    assert report.exit_code == 0
+    assert "自检通过" in render_report(report)
+
+
+def test_self_check_passes_on_complete_release_tree(tmp_path, monkeypatch, capsys):
+    locator = _make_release_tree(tmp_path)
+    _isolate_dirs(monkeypatch, tmp_path)
+    monkeypatch.setattr(self_check.subprocess, "run", _fake_process_run)
+    monkeypatch.setattr(self_check.importlib, "import_module", lambda name: object())
+
+    exit_code = run_self_check(locator=locator, report_dir=tmp_path / "reports")
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "[FAIL]" not in output
+    assert "自检通过" in output
+    reports = list((tmp_path / "reports").glob("self-check-*.txt"))
+    assert len(reports) == 1
+    assert "[PASS]" in reports[0].read_text(encoding="utf-8")
+
+
+def test_self_check_fails_when_tool_missing(tmp_path, monkeypatch):
+    locator = _make_release_tree(tmp_path)
+    (tmp_path / "tools" / "lua" / "unluac.jar").unlink()
+    _isolate_dirs(monkeypatch, tmp_path)
+    monkeypatch.setattr(self_check.subprocess, "run", _fake_process_run)
+    monkeypatch.setattr(self_check.importlib, "import_module", lambda name: object())
+
+    exit_code = run_self_check(locator=locator, report_dir=tmp_path)
+
+    assert exit_code == 1
+    report = SelfCheckReport(tuple(self_check._collect_checks(locator)))
+    failed_names = [result.name for result in report.failed]
+    assert "工具文件 unluac.jar" in failed_names
+
+
+def test_self_check_fails_without_dotnet8_runtime(tmp_path, monkeypatch):
+    locator = _make_release_tree(tmp_path)
+    _isolate_dirs(monkeypatch, tmp_path)
+
+    def run_without_dotnet8(args, **kwargs):
+        if str(args[0]).endswith("dotnet.exe"):
+            return subprocess.CompletedProcess(args, 0, stdout="Microsoft.NETCore.App 6.0.32", stderr="")
+        return _fake_process_run(args, **kwargs)
+
+    monkeypatch.setattr(self_check.subprocess, "run", run_without_dotnet8)
+    monkeypatch.setattr(self_check.importlib, "import_module", lambda name: object())
+
+    exit_code = run_self_check(locator=locator, report_dir=tmp_path)
+
+    assert exit_code == 1
+    report = SelfCheckReport(tuple(self_check._collect_checks(locator)))
+    dotnet = next(result for result in report.results if "dotnet" in result.name)
+    assert not dotnet.ok
+
+
+def test_self_check_fails_when_java_runtime_missing(tmp_path, monkeypatch):
+    # 冻结布局缺 runtimes/java：java() 抛 ToolNotFoundError，自检报 FAIL 而不是异常。
+    locator = _make_release_tree(tmp_path)
+    (tmp_path / "runtimes" / "java" / "bin" / "java.exe").unlink()
+    _isolate_dirs(monkeypatch, tmp_path)
+    monkeypatch.setattr(self_check.subprocess, "run", _fake_process_run)
+    monkeypatch.setattr(self_check.importlib, "import_module", lambda name: object())
+
+    exit_code = run_self_check(locator=locator, report_dir=tmp_path)
+
+    assert exit_code == 1
+    report = SelfCheckReport(tuple(self_check._collect_checks(locator)))
+    java = next(result for result in report.results if "Java" in result.name)
+    assert not java.ok

--- a/xl_updata_tool/tests/test_tool_locator.py
+++ b/xl_updata_tool/tests/test_tool_locator.py
@@ -1,0 +1,168 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+from app.platform import tool_locator
+from app.platform.tool_locator import ToolLocator, ToolNotFoundError, resource_root
+
+
+def _make_bundled_runtimes(root: Path, *, java=True, dotnet=True):
+    if java:
+        (root / "runtimes" / "java" / "bin").mkdir(parents=True, exist_ok=True)
+        (root / "runtimes" / "java" / "bin" / "java.exe").write_bytes(b"placeholder")
+    if dotnet:
+        (root / "runtimes" / "dotnet").mkdir(parents=True, exist_ok=True)
+        (root / "runtimes" / "dotnet" / "dotnet.exe").write_bytes(b"placeholder")
+
+
+def test_resource_root_follows_project_layout_in_dev():
+    assert resource_root() == Path(tool_locator.__file__).resolve().parents[2]
+    assert (resource_root() / "tools").is_dir()
+
+
+def test_resource_root_uses_meipass_when_frozen(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+
+    assert resource_root() == tmp_path
+    assert ToolLocator.create().tools == tmp_path / "tools"
+
+
+def test_java_prefers_bundled_runtime(tmp_path):
+    _make_bundled_runtimes(tmp_path)
+    locator = ToolLocator(root=tmp_path, frozen=False)
+
+    assert locator.java() == str(tmp_path / "runtimes" / "java" / "bin" / "java.exe")
+
+
+def test_java_falls_back_to_system_path_only_in_dev(tmp_path, monkeypatch):
+    monkeypatch.setattr(tool_locator.shutil, "which", lambda name: f"/system/{name}")
+    locator = ToolLocator(root=tmp_path, frozen=False)
+
+    assert locator.java() == "/system/java"
+    assert locator.dotnet() == "/system/dotnet"
+
+
+def test_java_never_falls_back_when_frozen(tmp_path, monkeypatch):
+    # 冻结模式即使 PATH 里有 java 也不允许使用，避免干净机器上行为漂移。
+    monkeypatch.setattr(tool_locator.shutil, "which", lambda name: f"/system/{name}")
+    locator = ToolLocator(root=tmp_path, frozen=True)
+
+    with pytest.raises(ToolNotFoundError):
+        locator.java()
+
+
+def test_dotnet_never_falls_back_when_frozen(tmp_path, monkeypatch):
+    monkeypatch.setattr(tool_locator.shutil, "which", lambda name: f"/system/{name}")
+    locator = ToolLocator(root=tmp_path, frozen=True)
+
+    with pytest.raises(ToolNotFoundError):
+        locator.dotnet()
+
+
+def test_java_dev_without_any_runtime_raises(tmp_path, monkeypatch):
+    monkeypatch.setattr(tool_locator.shutil, "which", lambda name: None)
+    locator = ToolLocator(root=tmp_path, frozen=False)
+
+    with pytest.raises(ToolNotFoundError):
+        locator.java()
+
+
+def test_tool_not_found_is_file_not_found_for_legacy_handlers():
+    # 既有调用方用 except FileNotFoundError 兜底，缺失运行时必须兼容该契约。
+    assert issubclass(ToolNotFoundError, FileNotFoundError)
+
+
+def test_assetstudio_command_uses_bundled_dotnet_when_frozen(tmp_path):
+    _make_bundled_runtimes(tmp_path)
+    locator = ToolLocator(root=tmp_path, frozen=True)
+
+    command = locator.assetstudio_command()
+
+    assert command == [
+        str(tmp_path / "runtimes" / "dotnet" / "dotnet.exe"),
+        str(tmp_path / "tools" / "AssetStudio" / "AssetStudio.CLI.dll"),
+    ]
+
+
+def test_assetstudio_command_falls_back_to_exe_in_plain_dev(tmp_path):
+    # 开发机没有 bundled dotnet 时保持现状：exe 直启，依赖系统 .NET 8。
+    locator = ToolLocator(root=tmp_path, frozen=False)
+
+    assert locator.assetstudio_command() == [
+        str(tmp_path / "tools" / "AssetStudio" / "AssetStudio.CLI.exe")
+    ]
+
+
+def test_assetstudio_command_prefers_bundled_dotnet_in_dev(tmp_path):
+    _make_bundled_runtimes(tmp_path)
+    locator = ToolLocator(root=tmp_path, frozen=False)
+
+    command = locator.assetstudio_command()
+
+    assert command[0] == str(tmp_path / "runtimes" / "dotnet" / "dotnet.exe")
+    assert command[1].endswith("AssetStudio.CLI.dll")
+
+
+def test_assetstudio_command_requires_dotnet_when_frozen(tmp_path):
+    locator = ToolLocator(root=tmp_path, frozen=True)
+
+    with pytest.raises(ToolNotFoundError):
+        locator.assetstudio_command()
+
+
+def test_dotnet_env_points_to_bundled_runtime(tmp_path):
+    _make_bundled_runtimes(tmp_path)
+    locator = ToolLocator(root=tmp_path, frozen=True)
+
+    env = locator.dotnet_env()
+
+    root = str(tmp_path / "runtimes" / "dotnet")
+    assert env == {"DOTNET_ROOT": root, "DOTNET_ROOT_X64": root}
+    assert locator.subprocess_env()["DOTNET_ROOT"] == root
+
+
+def test_dotnet_env_empty_without_bundled_runtime(tmp_path):
+    locator = ToolLocator(root=tmp_path, frozen=False)
+
+    assert locator.dotnet_env() == {}
+
+
+def test_ffmpeg_prefers_bundled_then_dev_path_fallback(tmp_path, monkeypatch):
+    locator = ToolLocator(root=tmp_path, frozen=False)
+    monkeypatch.setattr(tool_locator.shutil, "which", lambda name: f"/system/{name}")
+
+    assert locator.ffmpeg() == "/system/ffmpeg"
+
+    bundled = tmp_path / "tools" / "SpineViewer" / "ffmpeg.exe"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_bytes(b"placeholder")
+    assert locator.ffmpeg() == str(bundled)
+
+
+def test_ffmpeg_never_uses_system_path_when_frozen(tmp_path, monkeypatch):
+    monkeypatch.setattr(tool_locator.shutil, "which", lambda name: f"/system/{name}")
+    locator = ToolLocator(root=tmp_path, frozen=True)
+
+    assert locator.ffmpeg() == str(tmp_path / "tools" / "SpineViewer" / "ffmpeg.exe")
+
+
+def test_quickbms_and_fsb_extractor_live_under_subcontractors(tmp_path):
+    # 回归：environment.py 曾把 quickbms 错查成 tools/quickbms/ 独立目录。
+    locator = ToolLocator(root=tmp_path, frozen=True)
+
+    assert locator.quickbms() == str(
+        tmp_path / "tools" / "epic7_debank_v1_0" / "_subcontractors" / "quickbms.exe"
+    )
+    assert locator.fsb_extractor().endswith(str(Path("_subcontractors") / "fsb_aud_extr.exe"))
+
+
+def test_lua_and_viewer_tool_paths(tmp_path):
+    locator = ToolLocator(root=tmp_path, frozen=True)
+
+    assert locator.unluac_jar().endswith(str(Path("lua") / "unluac.jar"))
+    assert locator.unluac_opmap().endswith(str(Path("lua") / "opmap"))
+    assert locator.spineviewer_cli().endswith("SpineViewerCLI.exe")
+    assert locator.spineviewer_gui().endswith("SpineViewer.exe")
+    assert locator.vgmstream().endswith("vgmstream-cli.exe")

--- a/xl_updata_tool/tools/epic7_debank_v1_0/epic7_debank.py
+++ b/xl_updata_tool/tools/epic7_debank_v1_0/epic7_debank.py
@@ -415,20 +415,26 @@ def _process_bank_job(job, folder4subcontractors, folder_cur, python_exe, bank_t
                 "method": "vgmstream",
                 "elapsed": time.perf_counter() - started,
             }
-        execute_kwargs = {
-            "result_dir": job["result_dir"],
-            "timeout": bank_timeout,
-        }
-        if cancel_check is not None:
-            execute_kwargs["cancel_check"] = cancel_check
-        success, returncode = execute_quickbms_single(
-            job["bank_path"],
-            folder4subcontractors,
-            job["extract_dir"],
-            folder_cur,
-            python_exe,
-            **execute_kwargs,
-        )
+        if python_exe is None:
+            # 冻结模式且系统无 Python：QuickBMS -S 回调无法执行，直接判失败，
+            # 把 bank 交给结果统计，避免 quickbms 静默空跑。
+            _log(f"[音频bank] 跳过 QuickBMS 回退（无可用 Python）: {job['bank_name']}")
+            success, returncode = False, "quickbms_skipped_no_python"
+        else:
+            execute_kwargs = {
+                "result_dir": job["result_dir"],
+                "timeout": bank_timeout,
+            }
+            if cancel_check is not None:
+                execute_kwargs["cancel_check"] = cancel_check
+            success, returncode = execute_quickbms_single(
+                job["bank_path"],
+                folder4subcontractors,
+                job["extract_dir"],
+                folder_cur,
+                python_exe,
+                **execute_kwargs,
+            )
     audio_files = collect_audio_files(job["result_dir"])
     if returncode == "cancelled" or (cancel_check and cancel_check()):
         status = "cancelled"
@@ -503,7 +509,14 @@ def run(input_dir, output_dir, folder_cur=None, progress_callback=None, subdir_f
         folder_cur = os.path.dirname(os.path.abspath(__file__))
 
     if getattr(sys, 'frozen', False):
-        python_exe = "python"
+        # 冻结包内没有可执行 Python；quickbms -S 回调 _epic7_defsb.py 只能靠
+        # 系统 PATH 里的 python。干净机器上必然缺失，此处显式探测，缺失时
+        # 记 warning 并跳过 QuickBMS 回退（vgmstream 直解与 fsb_aud_extr 兜底
+        # 不受影响），而不是让每个 bank 静默失败一遍。
+        python_exe = shutil.which("python")
+        if python_exe is None:
+            _log("[音频bank] 警告: 冻结模式下未找到系统 Python，QuickBMS 回退阶段将被跳过，"
+                 "vgmstream 直解失败的 bank 会标记为失败")
     else:
         python_exe = psutil.Process(os.getpid()).name()
 


### PR DESCRIPTION
## 范围
Windows 便携 Release 打包管线：ToolLocator 统一外部工具定位、私有 Java 21（jlink）/ .NET 8 运行时、tools 裁剪 staging、生产版 PyInstaller spec、`--self-check`、release workflow。

## 状态说明
按需求方要求：**本分支保留，暂不合并进 main**。首个便携版 v1.60.2 从本分支构建发布。

## 验证
- pytest 172 项通过，ruff 全绿
- 本机构建 dist/XL 630MB，ZIP 266.3MB
- XL.exe --self-check 19/19 通过（bundled java 21.0.12 / dotnet 8.0.30 实跑）
- bundled dotnet 直拉 AssetStudio.CLI.dll 正常；GUI 冒烟启动正常

## 已知限制
- 冻结模式 QuickBMS 回退依赖系统 python，干净机器上该中间层跳过（有日志告警），vgmstream 直解 + fsb_aud_extr 兜底不受影响
- 未做干净 Windows 沙箱终验